### PR TITLE
feat: TailwindCSS updates to Screener/Results

### DIFF
--- a/screener-frontend/src/EligibilityResults.tsx
+++ b/screener-frontend/src/EligibilityResults.tsx
@@ -6,72 +6,91 @@ import checkIcon from "./assets/images/checkIcon.svg";
 import questionIcon from "./assets/images/questionIcon.svg";
 import xIcon from "./assets/images/xIcon.svg";
 
-export default function EligibilityResults({ results }: { results: Accessor<ResultDetail[] | undefined> }) {
+
+export default function EligibilityResults(
+  { results }: { results: Accessor<ResultDetail[] | undefined> }
+) {
   console.log(results());
   return (
     <div class="my-2 mx-12">
       <h2 class="text-gray-600 font-bold">Eligibility Results</h2>
       <For each={results() ?? []}>
-        {(benefit) => (
-          <div class="border-gray-500 border p-5 my-4 rounded-lg shadow-md">
-            <Switch>
-              <Match when={benefit.result === true}>
-                <p class="mb-3 bg-green-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
-                  Eligible
-                </p>
-              </Match>
-              <Match when={benefit.result === null}>
-                <p class="mb-3 bg-yellow-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
-                  Need more information
-                </p>
-              </Match>
-              <Match when={benefit.result === false}>
-                <p class="mb-3 bg-red-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
-                  Ineligible
-                </p>
-              </Match>
-            </Switch>
-            <h3 class="font-bold mb-2 text-lg">{benefit.displayName}</h3>
-            <div class="my-2">
-              <For each={benefit.checks ?? []}>
-                {(check) => (
-                  <p class="mb-1">
-                    <Switch>
-                      <Match when={check.result === true}>
-                        <img src={checkIcon} alt="" class="inline w-4 mr-2" />
-                      </Match>
-                      <Match when={check.result === null}>
-                        <img
-                          src={questionIcon}
-                          alt=""
-                          class="inline w-4 mr-2"
-                        />
-                      </Match>
-                      <Match when={check.result === false}>
-                        <img src={xIcon} alt="" class="inline w-4 mr-2" />
-                      </Match>
-                    </Switch>
-                    <span class="text-xs">{check.displayName}</span>
-                  </p>
-                )}
-              </For>
-            </div>
-            {benefit.info && (
-              <>
-                <h4 class="font-bold mb-1 text-sm">Overview</h4>
-                <p class="mb-4 text-xs">{benefit.info}</p>
-              </>
-            )}
-            {benefit.appLink && (
-              <a href={benefit.appLink} target="_blank">
-                <p class="bg-green-600 px-5 py-2 rounded-lg font-bold text-white w-fit text-sm">
-                  Apply Now
-                </p>
-              </a>
-            )}
-          </div>
-        )}
+        {(benefit) => <BenefitResult benefit={benefit}/>}
       </For>
+    </div>
+  );
+}
+
+function BenefitResult({ benefit }: { benefit: ResultDetail }) {
+  const isApplicationLinkEnabled: boolean = benefit.result;
+  const applicationLinkCls: string = (
+    isApplicationLinkEnabled ? "" : "pointer-events-none opacity-50"
+  );
+
+  return (
+    <div class="border-gray-500 border p-5 my-4 rounded-lg shadow-md">
+      <Switch>
+        <Match when={benefit.result === true}>
+          <p class="mb-3 bg-green-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
+            Eligible
+          </p>
+        </Match>
+        <Match when={benefit.result === null}>
+          <p class="mb-3 bg-yellow-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
+            Need more information
+          </p>
+        </Match>
+        <Match when={benefit.result === false}>
+          <p class="mb-3 bg-red-200 w-fit py-1 px-6 rounded-full font-bold text-gray-800 text-sm">
+            Ineligible
+          </p>
+        </Match>
+      </Switch>
+      <div class="[&:has(+div)]:mb-2">
+        <h3 class="font-bold text-lg">{benefit.displayName}</h3>
+        <For each={benefit.checks ?? []}>
+          {(check) => (
+            <p class="mb-1">
+              <Switch>
+                <Match when={check.result === true}>
+                  <img src={checkIcon} alt="" class="inline w-4 mr-2" />
+                </Match>
+                <Match when={check.result === null}>
+                  <img
+                    src={questionIcon}
+                    alt=""
+                    class="inline w-4 mr-2"
+                  />
+                </Match>
+                <Match when={check.result === false}>
+                  <img src={xIcon} alt="" class="inline w-4 mr-2" />
+                </Match>
+              </Switch>
+              <span class="text-xs">{check.displayName}</span>
+            </p>
+          )}
+        </For>
+      </div>
+      {benefit.info && (
+        <div class="[&:has(+div)]:mb-4">
+          <h4 class="font-bold mb-1 text-sm">Overview</h4>
+          <p class="text-xs">{benefit.info}</p>
+        </div>
+      )}
+      {benefit.appLink && (
+        <div class="[&:has(+div)]:mb-4">
+          <a href={benefit.appLink} target="_blank" class={applicationLinkCls}>
+            <p
+              class="
+                px-5 py-2 rounded-lg select-none
+                rounded-lg font-bold text-white w-fit text-sm
+                bg-green-600 hover:bg-green-700 transition-colors"
+            >
+              Apply Now
+            </p>
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/screener-frontend/src/Error.tsx
+++ b/screener-frontend/src/Error.tsx
@@ -2,7 +2,7 @@ export default function ErrorPage({ error }: { error: any }) {
   console.log(error);
   return (
     <div class="py-24 flex-col justify-center h-screen items-center">
-      <h1 class="text-center text-xl">
+      <h1 class="text-center text-[2em]">
         Sorry, there was an error loading the requested screener.
       </h1>
     </div>

--- a/screener-frontend/src/Home.tsx
+++ b/screener-frontend/src/Home.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <div class="py-24 flex-col justify-center h-screen items-center">
-      <h1 class="text-center text-xl">Benefit Decision Toolkit</h1>
+      <h1 class="text-center text-[2em]">Benefit Decision Toolkit</h1>
     </div>
   );
 }

--- a/screener-frontend/src/Loading.tsx
+++ b/screener-frontend/src/Loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
     <div class="py-24 flex-col justify-center h-screen items-center">
-      <h1 class="text-center text-xl">Loading Screener</h1>
+      <h1 class="text-center text-[2em]">Loading Screener</h1>
       <div class="mt-8 flex items-center justify-center h-20">
         <div class="w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
       </div>

--- a/screener-frontend/src/NotFound.tsx
+++ b/screener-frontend/src/NotFound.tsx
@@ -1,7 +1,7 @@
 export default function NotFound() {
   return (
     <div class="py-24 flex-col justify-center h-screen items-center">
-      <h1 class="text-center text-xl">404 Screener Not Found</h1>
+      <h1 class="text-center text-[2em]">404 Screener Not Found</h1>
     </div>
   );
 }

--- a/screener-frontend/src/index.css
+++ b/screener-frontend/src/index.css
@@ -1,13 +1,15 @@
 @import "tailwindcss";
 
-.fjs-powered-by {
-  display: none;
-}
-
 body {
   font-family: "IBM Plex Sans", sans-serif;
 }
 
-h1 {
+/* Hide Form.io branding */
+.fjs-powered-by {
+  display: none;
+}
+
+/* Increase size of h1 specifically in Form.io forms */
+.fjs-container h1 {
   font-size: 2em;
 }


### PR DESCRIPTION
Formatting updates:
--
- Added styling to disable Application Link if unable or ineligible.
- Updated h1 styling in index.css to only apply to Form.io h1 elements, so Tailwind can govern the font-size.
- For uniformity, updated all non-formio h1 elements to have a 2em font-size using `text-[2em]`.
- Wrapped different sections of Eligibilty Results in divs.
  - Updated these divs to have bottom padding only if another div follows them with `[&:has(+div)]:mb-XXX`
- Updated Application Button to change bg-color on hover, with transition.