### PR TITLE
138 one step development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ node_modules/
 *.ipr
 *.iml
 *.iws
+
+.quarkus/

--- a/README.md
+++ b/README.md
@@ -44,12 +44,38 @@ If you are interested in getting involved with the project, check out [our page 
 
 ## Local Development Setup
 
+Clone this repository:
 ```bash
 git clone https://github.com/CodeForPhilly/benefit-decision-toolkit.git
+```
 
+Go to the project's root directory:
+```bash
 cd benefit-decision-toolkit
 ```
 
-You can find instructions to work on each app within the project in their respective directories, which are linked above.
+To setup using the pre-defined [Devbox](https://www.jetify.com/docs/devbox/) configuration:
+*Note that this installs Devbox and Nix (if they aren't already installed).
+```bash
+bin/install-devbox && devbox run setup
+```
 
-Note that for the frontend apps, you will need an environment variable file from a teammate. Please do not commit this file to the repo.
+If you don't want to use devbox/nix, then you can install system dependencies (e.g. JDK, Node, Maven) manually (see devbox.json for the list) and run:
+```bash
+bin/setup
+```
+
+If using devbox, then run the shell to load dependencies:
+```bash
+devbox shell
+# Consider using direnv and/or the VS Code extensions (Devbox and Direnv) to automate this step.
+```
+
+Then start apps as needed, e.g.:
+```bash
+cd builder-frontend && npm run dev
+```
+
+You can find additional instructions to work on each app within the project in their respective directories, which are linked above.
+
+Note that for the frontend apps, you will need a .env file from a teammate. Please do not commit this file to the repo.

--- a/bin/functions
+++ b/bin/functions
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+  printf "${BLUE}[INFO]${NC} %s\n" "$1"
+}
+
+print_success() {
+  printf "${GREEN}[SUCCESS]${NC} %s\n" "$1"
+}
+
+print_warning() {
+  printf "${YELLOW}[WARNING]${NC} %s\n" "$1"
+}
+
+print_error() {
+  printf "${RED}[ERROR]${NC} %s\n" "$1"
+}
+
+# Function to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ask_user() {
+  local prompt="$1"
+  local default="${2:-n}"
+
+  if [[ "$default" == "y" ]]; then
+    prompt_suffix="[Y/n]"
+  else
+    prompt_suffix="[y/N]"
+  fi
+
+  while true; do
+    read -p "$prompt $prompt_suffix: " -r answer
+    answer=${answer:-$default}
+
+    case "$answer" in
+    [Yy] | [Yy][Ee][Ss]) return 0 ;;
+    [Nn] | [Nn][Oo]) return 1 ;;
+    *) echo "Please answer yes or no." ;;
+    esac
+  done
+}

--- a/bin/install-devbox
+++ b/bin/install-devbox
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/functions"
+
+# Check if we're in the right directory
+# TODO: actually check the directory as well as the devbox.json?
+if [ ! -f "devbox.json" ]; then
+  print_error "Please run this script from the root of the benefit-decision-toolkit project"
+  exit 1
+fi
+
+print_status "🔍 Checking for existing devbox installation..."
+
+if ! command_exists devbox; then
+  print_warning "Devbox not found. Installing devbox..."
+  if command_exists curl; then
+    curl -fsSL https://get.jetify.com/devbox/install.sh | bash
+    print_success "Devbox installed"
+  else
+    print_error "curl not found. Please install devbox manually: https://www.jetify.com/devbox/docs/contributor-quickstart/"
+    exit 1
+  fi
+else
+  print_status "devbox already installed."
+fi
+
+print_status "📦 Setting up devbox environment..."
+if [ -f "devbox.json" ]; then
+  devbox install
+  print_success "Devbox environment initialized"
+else
+  print_error "devbox.json not found"
+  exit 1
+fi

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Benefit Decision Toolkit - One-Step Developer Setup Script
+# This script streamlines setup of a development environment for the Benefit Decision Toolkit
+
+set -e # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/functions"
+
+print_status "🚀 Starting Benefit Decision Toolkit Developer Setup..."
+
+if [[ "$DEVBOX_SHELL_ENABLED" != "1" ]]; then
+  if ask_user "This project is configured to use devbox (https://www.jetify.com/devbox) to manage system dependencies. Do you want to use devbox? (default=yes)" "y"; then
+    echo ""
+    echo "Devbox instructions:"
+    echo ""
+    echo "1. If you already have devbox installed, then run:"
+    echo "  \$ devbox run setup"
+    echo ""
+    echo "2. If you don't already have devbox installed (or you're not sure), then run:"
+    echo "  \$ bin/install-devbox && devbox run setup"
+    echo ""
+    exit 0
+  else
+    print_warning "Setup won't use devbox; system dependencies are the developer's responsibility. See devbox.json for the list of dependencies needed."
+    sleep 2
+  fi
+fi
+
+print_status "📦 Installing frontend dependencies..."
+
+if ! command_exists npm; then
+  print_error "npm not found. Please install node manually or use devbox to manage dependencies."
+  exit 1
+fi
+
+print_status "Installing builder-frontend dependencies..."
+cd builder-frontend
+if [ -f "package.json" ]; then
+  npm install
+  print_success "builder-frontend dependencies installed"
+else
+  print_error "package.json not found in builder-frontend"
+  exit 1
+fi
+cd ..
+
+print_status "Installing screener-frontend dependencies..."
+cd screener-frontend
+if [ -f "package.json" ]; then
+  npm install
+  print_success "screener-frontend dependencies installed"
+else
+  print_error "package.json not found in screener-frontend"
+  exit 1
+fi
+cd ..
+
+print_status "Finished installing frontend dependencies."
+
+print_status "📦 Installing backend dependencies..."
+
+if ! command_exists mvn; then
+  print_error "mvn not found. Please install maven manually or use devbox to manage dependendcies."
+  exit 1
+fi
+
+print_status "Installing library-api dependencies..."
+cd library-api
+mvn clean package
+print_success "library-api dependencies installed"
+cd ..
+
+print_status "Installing builder-api dependencies..."
+cd builder-api
+# TODO: are the tests important to run here? (one of them was failing for me)
+mvn clean package -DskipTests
+print_success "builder-api dependencies installed"
+cd ..
+
+print_status "Installing screener-api dependencies..."
+cd screener-api
+mvn clean package
+print_success "screener-api dependencies installed"
+cd ..
+
+print_status "Finished installing backend dependencies."
+
+print_success "🎉 Developer setup completed successfully!"
+echo ""
+echo "📋 Next Steps:"
+echo "1. Ask a teammate to help you setup .env files in builder-frontend and screener-frontend."
+echo "2. If using devbox, then:"
+echo "  a. Run 'devbox shell' within the project root directory to load dependencies. (https://www.jetify.com/docs/devbox/cli_reference/devbox_shell/)"
+echo "  b. Consider using the direnv integration to load dependencies automatically. (https://www.jetify.com/docs/devbox/ide_configuration/direnv/)"
+echo "  c. If you use VS Code, then consider installing the Devbox and Direnv extensions."
+echo "3. Run the web apps locally using 'npm run dev' from within builder-frontend and screener-frontend directories."
+echo "4. Run the library-api application using 'quarkus dev' within the library-api directory."
+echo ""
+print_status "Happy coding! 🚀"

--- a/bin/teardown
+++ b/bin/teardown
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# NOTE: this is maybe temporary... for helping to test project setup
+
+echo -n "Removing all maven dependencies"
+rm -rf ~/.m2/repository
+echo "...done"
+
+echo -n "Removing all npm dependencies"
+rm -rf builder-frontend/node_modules screener-frontend/node_modules
+echo "...done"
+
+echo -n "Removing devbox"
+rm /usr/local/bin/devbox
+rm -rf ~/.cache/devbox
+rm -rf ~/.local/share/devbox
+echo "...done"
+
+echo -n "Removing nix"
+rm -rf /nix ~/.nix-channels ~/.nix-defexpr ~/.nix-profile
+echo "...done"

--- a/devbox.json
+++ b/devbox.json
@@ -4,18 +4,18 @@
     "maven@latest",
     "quarkus@latest",
     "jdk21@latest",
-    "google-cloud-sdk@latest",
-    "podman@latest",
-    "docker@latest",
-    "firebase-tools@latest"
+    "nodejs@20",
+    "firebase-tools@latest",
+    "google-cloud-sdk@latest"
   ],
   "shell": {
     "init_hook": [
-      "echo 'Welcome to devbox!' > /dev/null"
+      "echo 'Welcome to devbox!'",
+      "command -v mise >/dev/null && mise deactivate || true"
     ],
     "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
+      "setup": [
+        "bin/setup"
       ]
     }
   }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,54 +1,6 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "docker@latest": {
-      "last_modified": "2025-08-08T08:05:48Z",
-      "resolved": "github:NixOS/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1#docker",
-      "source": "devbox-search",
-      "version": "28.3.3",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/6x679ch4cqa5aywjsrnplsasv5rp0mak-docker-28.3.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/6x679ch4cqa5aywjsrnplsasv5rp0mak-docker-28.3.3"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/8jb799sr948h68avj9k3xkvznv10f470-docker-28.3.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/8jb799sr948h68avj9k3xkvznv10f470-docker-28.3.3"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/g3h7m6qsx5rkb908qcqi4a6kflvcriz5-docker-28.3.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/g3h7m6qsx5rkb908qcqi4a6kflvcriz5-docker-28.3.3"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/r0vqz3dsdhw31gyk098qgrw61vwmc7a1-docker-28.3.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/r0vqz3dsdhw31gyk098qgrw61vwmc7a1-docker-28.3.3"
-        }
-      }
-    },
     "firebase-tools@latest": {
       "last_modified": "2025-08-08T08:05:48Z",
       "resolved": "github:NixOS/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1#firebase-tools",
@@ -98,8 +50,8 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2025-08-25T22:07:10Z",
-      "resolved": "github:NixOS/nixpkgs/84c256e42600cb0fdf25763b48d28df2f25a0c8b?lastModified=1756159630&narHash=sha256-ohMvsjtSVdT%2FbruXf5ClBh8ZYXRmD4krmjKrXhEvwMg%3D"
+      "last_modified": "2025-09-12T04:37:21Z",
+      "resolved": "github:NixOS/nixpkgs/ad4e6dd68c30bc8bd1860a27bc6f0c485bd7f3b6?lastModified=1757651841&narHash=sha256-Lh9QoMzTjY%2FO4LqNwcm6s%2FWSYStDmCH6f3V%2FizwlkHc%3D"
     },
     "google-cloud-sdk@latest": {
       "last_modified": "2025-07-28T17:09:23Z",
@@ -233,77 +185,90 @@
         }
       }
     },
-    "podman@latest": {
-      "last_modified": "2025-08-04T20:54:38Z",
-      "resolved": "github:NixOS/nixpkgs/cab778239e705082fe97bb4990e0d24c50924c04#podman",
+    "nodejs@20": {
+      "last_modified": "2025-08-10T04:38:50Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/641d909c4a7538f1539da9240dedb1755c907e40#nodejs_20",
       "source": "devbox-search",
-      "version": "5.5.2",
+      "version": "20.19.4",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/d4qsjh71z5imdjn4fkixfq040i0l56bz-podman-5.5.2",
+              "path": "/nix/store/2xza7g9y47n717w43qdd1ikc0y10qh16-nodejs-20.19.4",
               "default": true
             },
             {
-              "name": "man",
-              "path": "/nix/store/lzqbp5rjw8zldnwy7zzzp6z5lffilsmh-podman-5.5.2-man",
-              "default": true
+              "name": "dev",
+              "path": "/nix/store/yvcblmgwq9md8f2mpw8ra2cf3b7jkm7b-nodejs-20.19.4-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/x5b5wq2qjfq9di05qlja0wd7ypqcnxc8-nodejs-20.19.4-libv8"
             }
           ],
-          "store_path": "/nix/store/d4qsjh71z5imdjn4fkixfq040i0l56bz-podman-5.5.2"
+          "store_path": "/nix/store/2xza7g9y47n717w43qdd1ikc0y10qh16-nodejs-20.19.4"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rq6rlyb9ihran9jqsadq6rgv5vc5ri1h-podman-5.5.2",
+              "path": "/nix/store/rpk03376gp4vrjrahx11ncr50ji6cvhw-nodejs-20.19.4",
               "default": true
             },
             {
-              "name": "man",
-              "path": "/nix/store/b81md27ig417wpqmgpj6a6lzb3vcd0b6-podman-5.5.2-man",
-              "default": true
+              "name": "dev",
+              "path": "/nix/store/qai8hc7vnmxil2b9ab86gv2wrg5yx67q-nodejs-20.19.4-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/4d388d34pvahifbini4a28wm1wzi9c6l-nodejs-20.19.4-libv8"
             }
           ],
-          "store_path": "/nix/store/rq6rlyb9ihran9jqsadq6rgv5vc5ri1h-podman-5.5.2"
+          "store_path": "/nix/store/rpk03376gp4vrjrahx11ncr50ji6cvhw-nodejs-20.19.4"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/in7kybnm92wgpkz9vrdpwq6a4z2vzcqb-podman-5.5.2",
+              "path": "/nix/store/x7ail2dy0fi3742yridnnk3hdlp16cls-nodejs-20.19.4",
               "default": true
             },
             {
-              "name": "man",
-              "path": "/nix/store/gw2ia71qbhxnjf5xw2qa66kih03k0543-podman-5.5.2-man",
-              "default": true
+              "name": "dev",
+              "path": "/nix/store/pcjlzxxfrgvw9pp0ir5v58h7n1al9xrn-nodejs-20.19.4-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/zjmxxl948wyf7vczhz56rh6nmmysm6bl-nodejs-20.19.4-libv8"
             }
           ],
-          "store_path": "/nix/store/in7kybnm92wgpkz9vrdpwq6a4z2vzcqb-podman-5.5.2"
+          "store_path": "/nix/store/x7ail2dy0fi3742yridnnk3hdlp16cls-nodejs-20.19.4"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/la6fdv93ng406rl4rkc372f0l7qbx51p-podman-5.5.2",
+              "path": "/nix/store/l62aza10kx0xp1f235q2lbrzzqj5lcs9-nodejs-20.19.4",
               "default": true
             },
             {
-              "name": "man",
-              "path": "/nix/store/3w7yy7xg9lzirnnk30dahcblfnxr4ldx-podman-5.5.2-man",
-              "default": true
+              "name": "dev",
+              "path": "/nix/store/a73v659hn20f543z519cmm3vplah8pns-nodejs-20.19.4-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/5q0dhajwwv1pfwnkm79wphvgi19wi49c-nodejs-20.19.4-libv8"
             }
           ],
-          "store_path": "/nix/store/la6fdv93ng406rl4rkc372f0l7qbx51p-podman-5.5.2"
+          "store_path": "/nix/store/l62aza10kx0xp1f235q2lbrzzqj5lcs9-nodejs-20.19.4"
         }
       }
     },
     "quarkus@latest": {
-      "last_modified": "2025-07-28T17:09:23Z",
-      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#quarkus",
+      "last_modified": "2025-08-11T16:06:55Z",
+      "resolved": "github:NixOS/nixpkgs/4e942f9ef5b35526597c354d1ded817d1c285ef1#quarkus",
       "source": "devbox-search",
       "version": "3.24.5",
       "systems": {


### PR DESCRIPTION
Resolves #138.  See my planned steps for creating a better dev experience [here](https://github.com/CodeForPhilly/benefit-decision-toolkit/issues/138#issuecomment-3325136874)

@Michael-Dratch @Justin-MacIntosh @earth-walker - Can you guys kick the tires on this?

To run setup (including installing devbox and nix):
```bash
bin/install-devbox && devbox run setup
```
Then to develop in the context of the devbox dependencies*:
```bash
devbox shell
```
*Consider using [direnv](https://www.jetify.com/docs/devbox/ide_configuration/direnv/) and the [VS Code extensions](https://www.jetify.com/docs/devbox/ide_configuration/vscode/) for a smoother experience.

To run setup WITHOUT using devbox/nix (assumes you already have Maven/Quarkus/JDK/Node installed):
```bash
# this just installs the npm and mvn dependencies (for now)
bin/setup
```

The (temporary?) teardown script I'm using for testing/cleanup purposes:
```bash
# Note: the Nix uninstall part of this script won't work on MacOS, you'll have to follow the steps here: 
# https://nix.dev/manual/nix/2.21/installation/uninstall#macos
sudo bin/teardown
```

### Known Issues:
- The  `devbox shell` might not play nicely with version managers (nodenv, asdf, mise, etc) or potentially other stuff that does clever things with $PATH.  I built in a fix for mise into the devbox.json init script (since that's what I use when I don't use devbox), but I didn't try to handle all the other possible things one might have installed.