### PR TITLE
load and export emulator data on startup and shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ firebase-debug.*.log*
 # it commented so all members can deploy to the same project(s) in .firebaserc.
 # .firebaserc
 
+emulator-data/
+
 # Runtime data
 pids
 *.pid

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -3,11 +3,11 @@ version: "0.5"
 processes:
   firebase-emulators:
     description: This process runs the local firebase emulators used in the project.
-    command: firebase emulators:start --project demo-bdt-dev --only auth,storage,firestore
+    command: firebase emulators:start --project demo-bdt-dev --only auth,storage,firestore --import ./emulator-data --export-on-exit
     ready_log_line: "All emulators ready!"
   builder-api:
     description: This process runs the builder-api in dev mode on port ${QUARKUS_HTTP_PORT}.
-    command: quarkus dev -Ddebug=false
+    command: quarkus dev -Ddebug=5005
     working_dir: builder-api/
     environment:
       - "QUARKUS_CONSOLE_COLOR=true"


### PR DESCRIPTION
Firebase emulators provide the ability to load seed data on startup and also export emulator data on shutdown. I updated the process compose to enable these features. 

When the app running locally is shutdown, the existing emulator data is stored in the emulator-data folder at the root of the project. This folder is git ignored so will be unique for each dev and not committed to the repo.

When the app starts up it will load the data from this folder into the emulators if it exists. This will allow the data in the local emulators to be persistent.

If a dev wants to reset the emulator data they will need to go to the emulator UI and manually clear the data.