### PR TITLE
updated screener evaluation

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -133,7 +133,7 @@ public class EligibilityCheckResource {
                     .build();
         }
         try {
-            String filePath = storageService.getCheckDmnModelPath(userId, checkId);
+            String filePath = storageService.getCheckDmnModelPath(checkId);
             storageService.writeStringToStorage(filePath, dmnModel, "application/xml");
             Log.info("Saved DMN model of check " + checkId + " to storage");
 
@@ -278,10 +278,10 @@ public class EligibilityCheckResource {
             String publishedCheckId = eligibilityCheckRepository.saveNewPublishedCustomCheck(check);
 
             // save published check DMN to storage
-            Optional<String> workingDmnOpt = storageService.getStringFromStorage(storageService.getCheckDmnModelPath(userId, check.getId()));
+            Optional<String> workingDmnOpt = storageService.getStringFromStorage(storageService.getCheckDmnModelPath(check.getId()));
             if (workingDmnOpt.isPresent()){
                 String workingDmn = workingDmnOpt.get();
-                storageService.writeStringToStorage(storageService.getCheckDmnModelPath(userId, publishedCheckId), workingDmn, "application/xml");
+                storageService.writeStringToStorage(storageService.getCheckDmnModelPath(publishedCheckId), workingDmn, "application/xml");
             }
         } catch (Exception e){
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/builder-api/src/main/java/org/acme/model/domain/CheckConfig.java
+++ b/builder-api/src/main/java/org/acme/model/domain/CheckConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CheckConfig {
     private String checkId;
+    private String checkName;
     private Map<String, Object> parameters;
 
     public String getCheckId() {
@@ -23,5 +24,13 @@ public class CheckConfig {
 
     public void setParameters(Map<String, Object> parameters) {
         this.parameters = parameters;
+    }
+
+    public String getCheckName() {
+        return checkName;
+    }
+
+    public void setCheckName(String checkName) {
+        this.checkName = checkName;
     }
 }

--- a/builder-api/src/main/java/org/acme/persistence/GoogleStorageService.java
+++ b/builder-api/src/main/java/org/acme/persistence/GoogleStorageService.java
@@ -141,8 +141,8 @@ public class GoogleStorageService implements StorageService {
     }
 
     @Override
-    public String getCheckDmnModelPath(String userId, String checkId){
-        return "check/" + userId + "/" + checkId + ".dmn";
+    public String getCheckDmnModelPath(String checkId){
+        return "check/" + checkId + ".dmn";
     }
 
     @Override

--- a/builder-api/src/main/java/org/acme/persistence/StorageService.java
+++ b/builder-api/src/main/java/org/acme/persistence/StorageService.java
@@ -23,7 +23,7 @@ public interface StorageService {
 
     String getScreenerPublishedFormSchemaPath(String screenerId);
 
-    String getCheckDmnModelPath(String userId, String checkId);
+    String getCheckDmnModelPath(String checkId);
 
     Map<String, Object> getFormSchemaFromStorage(String filePath);
 

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -101,7 +101,7 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
         ObjectMapper mapper = new ObjectMapper();
         EligibilityCheck check = mapper.convertValue(data, EligibilityCheck.class);
 
-        String dmnPath = storageService.getCheckDmnModelPath(userId, checkId);
+        String dmnPath = storageService.getCheckDmnModelPath(checkId);
         Optional<String> dmnModel = storageService.getStringFromStorage(dmnPath);
         dmnModel.ifPresent(check::setDmnModel);
 

--- a/builder-api/src/main/java/org/acme/service/KieDmnService.java
+++ b/builder-api/src/main/java/org/acme/service/KieDmnService.java
@@ -118,7 +118,9 @@ public class KieDmnService implements DmnService {
         DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, context);
 
         // Collect and interpret results
-        List<DMNDecisionResult> decisionResults = dmnResult.getDecisionResults();
+        List<DMNDecisionResult> decisionResults = dmnResult.getDecisionResults().stream()
+                .filter(result -> result.getDecisionName().equals(dmnModelName)).toList();
+
         if (decisionResults.isEmpty()) {
             throw new RuntimeException("No decision results from DMN evaluation");
         }

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/EligibilityCheckListView.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/EligibilityCheckListView.tsx
@@ -2,7 +2,6 @@ import { Accessor, For, Resource, Setter } from "solid-js";
 
 import type { Benefit, CheckConfig, EligibilityCheck } from "@/types";
 
-
 export type EligibilityCheckListMode = "user-defined" | "public";
 interface CheckModeConfig {
   mode: EligibilityCheckListMode;
@@ -19,7 +18,8 @@ const PublicCheckConfig: CheckModeConfig = {
 const UserDefinedCheckConfig: CheckModeConfig = {
   mode: "user-defined",
   title: "User defined eligibility checks",
-  description: "Browse and select your own custom checks to add to your benefit.",
+  description:
+    "Browse and select your own custom checks to add to your benefit.",
   buttonTitle: "Your checks",
 };
 
@@ -32,31 +32,42 @@ const UserDefinedCheckConfig: CheckModeConfig = {
     - publicChecks: resource containing the list of public eligibility checks
     - userDefinedChecks: resource containing the list of user-defined eligibility checks
 */
-const EligibilityCheckListView = (
-  { benefit, addCheck, removeCheck, mode, setMode, publicChecks, userDefinedChecks }:
-  {
-    benefit: Accessor<Benefit>;
-    addCheck: (newCheck: CheckConfig) => void;
-    removeCheck: (indexToRemove: number) => void;
-    mode: Accessor<EligibilityCheckListMode>,
-    setMode: Setter<EligibilityCheckListMode>,
-    publicChecks: Resource<EligibilityCheck[]>,
-    userDefinedChecks: Resource<EligibilityCheck[]>,
-  }
-) => {
-  const activeCheckConfig: Accessor<CheckModeConfig> = (
-    () => mode() === "public" ? PublicCheckConfig : UserDefinedCheckConfig
-  );
-  const activeChecks: Accessor<Resource<EligibilityCheck[]>> = (
-    () => mode() === "public" ? publicChecks : userDefinedChecks
-  );
+const EligibilityCheckListView = ({
+  benefit,
+  addCheck,
+  removeCheck,
+  mode,
+  setMode,
+  publicChecks,
+  userDefinedChecks,
+}: {
+  benefit: Accessor<Benefit>;
+  addCheck: (newCheck: CheckConfig) => void;
+  removeCheck: (indexToRemove: number) => void;
+  mode: Accessor<EligibilityCheckListMode>;
+  setMode: Setter<EligibilityCheckListMode>;
+  publicChecks: Resource<EligibilityCheck[]>;
+  userDefinedChecks: Resource<EligibilityCheck[]>;
+}) => {
+  const activeCheckConfig: Accessor<CheckModeConfig> = () =>
+    mode() === "public" ? PublicCheckConfig : UserDefinedCheckConfig;
+  const activeChecks: Accessor<Resource<EligibilityCheck[]>> = () =>
+    mode() === "public" ? publicChecks : userDefinedChecks;
   const onEligibilityCheckToggle = (check: EligibilityCheck) => {
-    const isCheckSelected = benefit().checks.some((selected) => selected.checkId === check.id);
+    const isCheckSelected = benefit().checks.some(
+      (selected) => selected.checkId === check.id
+    );
     if (isCheckSelected) {
-      const checkIndexToRemove = benefit().checks.findIndex((selected) => selected.checkId === check.id);
+      const checkIndexToRemove = benefit().checks.findIndex(
+        (selected) => selected.checkId === check.id
+      );
       removeCheck(checkIndexToRemove);
     } else {
-      const checkConfig: CheckConfig = { checkId: check.id, parameters: {} };
+      const checkConfig: CheckConfig = {
+        checkId: check.id,
+        checkName: check.name,
+        parameters: {},
+      };
       addCheck(checkConfig);
     }
   };
@@ -65,14 +76,18 @@ const EligibilityCheckListView = (
     <>
       <div class="p-4">
         <div class="flex items-center mb-2">
-          <div class="text-2xl font-bold">
-            {activeCheckConfig().title}
-          </div>
+          <div class="text-2xl font-bold">{activeCheckConfig().title}</div>
           <div class="ml-auto flex gap-2">
-            <For each={[PublicCheckConfig, UserDefinedCheckConfig] as CheckModeConfig[]}>
+            <For
+              each={
+                [PublicCheckConfig, UserDefinedCheckConfig] as CheckModeConfig[]
+              }
+            >
               {(modeOption) => (
                 <div
-                  class={`btn-default ${mode() === modeOption.mode ? "btn-blue" : "btn-gray"}`}
+                  class={`btn-default ${
+                    mode() === modeOption.mode ? "btn-blue" : "btn-gray"
+                  }`}
                   onClick={() => setMode(modeOption.mode)}
                   title={modeOption.buttonTitle}
                 >
@@ -82,9 +97,7 @@ const EligibilityCheckListView = (
             </For>
           </div>
         </div>
-        <div>
-          { activeCheckConfig().description }
-        </div>
+        <div>{activeCheckConfig().description}</div>
       </div>
       <table class="table-auto w-full mt-4 border-collapse">
         <thead>
@@ -102,7 +115,7 @@ const EligibilityCheckListView = (
               </td>
             </tr>
           )}
-          {(activeChecks()() && activeChecks()().length === 0) && (
+          {activeChecks()() && activeChecks()().length === 0 && (
             <tr>
               <td colSpan={3} class="p-4 font-bold text-center text-gray-600">
                 No checks available.
@@ -124,15 +137,17 @@ const EligibilityCheckListView = (
   );
 };
 
-const EligibilityCheckRow = (
-  { check, selectedCheckConfigs, onToggle }:
-  {
-    check: EligibilityCheck;
-    selectedCheckConfigs: CheckConfig[];
-    onToggle: (check: EligibilityCheck) => void;
-  }
-) => {
-  const isCheckSelected = () => selectedCheckConfigs.some((selected) => selected.checkId === check.id);
+const EligibilityCheckRow = ({
+  check,
+  selectedCheckConfigs,
+  onToggle,
+}: {
+  check: EligibilityCheck;
+  selectedCheckConfigs: CheckConfig[];
+  onToggle: (check: EligibilityCheck) => void;
+}) => {
+  const isCheckSelected = () =>
+    selectedCheckConfigs.some((selected) => selected.checkId === check.id);
 
   return (
     <tr>
@@ -144,11 +159,9 @@ const EligibilityCheckRow = (
           onChange={() => onToggle(check)}
         />
       </td>
+      <td class="eligibility-check-table-cell border-top">{check.name}</td>
       <td class="eligibility-check-table-cell border-top">
-        { check.name }
-      </td>
-      <td class="eligibility-check-table-cell border-top">
-        { check.description }
+        {check.description}
       </td>
     </tr>
   );

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
@@ -4,48 +4,60 @@ import SelectedCheckModal from "./modals/ConfigureCheckModal";
 
 import { titleCase } from "@/utils/title_case";
 
-import type { CheckConfig, EligibilityCheck, ParameterDefinition, ParameterValues } from "@/types";
-
+import type {
+  CheckConfig,
+  EligibilityCheck,
+  ParameterDefinition,
+  ParameterValues,
+} from "@/types";
 
 interface ParameterWithConfiguredValue {
   parameter: ParameterDefinition;
   value: string | number | boolean | string[] | undefined;
 }
 
-const SelectedEligibilityCheck = (
-  { check, checkConfig, checkIndex, updateCheckConfigParams }:
-  {
-    check: EligibilityCheck;
-    checkConfig: Accessor<CheckConfig>;
-    checkIndex: number;
-    updateCheckConfigParams: (checkIndex: number, newCheckData: ParameterValues) => void
-  }
-) => {
-  const [configuringCheckModalOpen, setConfiguringCheckModalOpen] = createSignal(false);
+const SelectedEligibilityCheck = ({
+  check,
+  checkConfig,
+  checkIndex,
+  updateCheckConfigParams,
+}: {
+  check: EligibilityCheck;
+  checkConfig: Accessor<CheckConfig>;
+  checkIndex: number;
+  updateCheckConfigParams: (
+    checkIndex: number,
+    newCheckData: ParameterValues
+  ) => void;
+}) => {
+  const [configuringCheckModalOpen, setConfiguringCheckModalOpen] =
+    createSignal(false);
 
-  const checkParameters: ParameterWithConfiguredValue[] = check.parameters.map((param) => {
-    return { parameter: param, value: checkConfig().parameters[param.key]! };
-  });
+  const checkParameters: ParameterWithConfiguredValue[] = check.parameters.map(
+    (param) => {
+      return { parameter: param, value: checkConfig().parameters[param.key]! };
+    }
+  );
 
-  const unfilledRequiredParameters = () => {return []};
+  const unfilledRequiredParameters = () => {
+    return [];
+  };
   // const unfilledRequiredParameters = () => {return check.parameters.filter(
   //   (param) => param.required && param.value === undefined
   // )};
 
   return (
     <>
-      <div 
-        onClick={() => { setConfiguringCheckModalOpen(true) }}
+      <div
+        onClick={() => {
+          setConfiguringCheckModalOpen(true);
+        }}
         class="
           mb-4 p-4 cursor-pointer select-none
           border-2 border-gray-200 rounded-lg hover:bg-gray-200"
       >
-        <div class="text-xl font-bold mb-2">
-          {titleCase(check.id)}
-        </div>
-        <div class="pl-2 [&:has(+div)]:mb-2">
-          {check.description}
-        </div>
+        <div class="text-xl font-bold mb-2">{titleCase(check.name)}</div>
+        <div class="pl-2 [&:has(+div)]:mb-2">{check.description}</div>
         {check.inputs.length > 0 && (
           <div class="[&:has(+div)]:mb-2">
             <div class="text-lg font-bold pl-2">Inputs</div>
@@ -63,10 +75,14 @@ const SelectedEligibilityCheck = (
           <div class="[&:has(+div)]:mb-2">
             <div class="text-lg font-bold pl-2">Parameters</div>
             <For each={checkParameters}>
-              {({parameter, value}: ParameterWithConfiguredValue) => {
+              {({ parameter, value }: ParameterWithConfiguredValue) => {
                 const getLabel = () => {
-                  return value !== undefined ? value.toString() : <span class="text-yellow-700">Not configured</span>;
-                }
+                  return value !== undefined ? (
+                    value.toString()
+                  ) : (
+                    <span class="text-yellow-700">Not configured</span>
+                  );
+                };
                 return (
                   <div class="flex gap-2 pl-4">
                     <div>{titleCase(parameter.key)}:</div>
@@ -79,20 +95,22 @@ const SelectedEligibilityCheck = (
         )}
         {unfilledRequiredParameters().length > 0 && (
           <div class="mt-2 text-yellow-700 font-bold">
-            Warning: This check has required parameter(s) that are not configured. Click here to edit.
+            Warning: This check has required parameter(s) that are not
+            configured. Click here to edit.
           </div>
         )}
       </div>
-      {
-        configuringCheckModalOpen() &&
+      {configuringCheckModalOpen() && (
         <SelectedCheckModal
           check={check}
           checkConfig={checkConfig}
           checkIndex={checkIndex}
           updateCheckConfigParams={updateCheckConfigParams}
-          closeModal={() => { setConfiguringCheckModalOpen(false); }}
+          closeModal={() => {
+            setConfiguringCheckModalOpen(false);
+          }}
         />
-      }
+      )}
     </>
   );
 };

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/modals/ConfigureCheckModal.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/modals/ConfigureCheckModal.tsx
@@ -13,39 +13,46 @@ import type {
   StringParameter,
 } from "@/types";
 
-
-const ConfigureCheckModal = (
-  { checkConfig, check, checkIndex, updateCheckConfigParams, closeModal }:
-  {
-    checkConfig: Accessor<CheckConfig>;
-    check: EligibilityCheck;
-    checkIndex: number
-    updateCheckConfigParams: (checkIndex: number, newCheckData: ParameterValues) => void;
-    closeModal: () => void
-  }
-) => {
-  const [tempCheck, setTempCheck] = createStore<CheckConfig>(
-    { checkId: checkConfig().checkId, parameters: { ...checkConfig().parameters } }
-  );
+const ConfigureCheckModal = ({
+  checkConfig,
+  check,
+  checkIndex,
+  updateCheckConfigParams,
+  closeModal,
+}: {
+  checkConfig: Accessor<CheckConfig>;
+  check: EligibilityCheck;
+  checkIndex: number;
+  updateCheckConfigParams: (
+    checkIndex: number,
+    newCheckData: ParameterValues
+  ) => void;
+  closeModal: () => void;
+}) => {
+  const [tempCheck, setTempCheck] = createStore<CheckConfig>({
+    checkId: checkConfig().checkId,
+    checkName: checkConfig().checkName,
+    parameters: { ...checkConfig().parameters },
+  });
 
   const confirmAndClose = () => {
     updateCheckConfigParams(checkIndex, tempCheck.parameters);
     closeModal();
-  }
+  };
 
   return (
     <div class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
       <div class="bg-white px-12 py-8 rounded-xl max-w-140 w-1/2 min-w-80">
-        <div class="text-2xl mb-4">Configure Check: {titleCase(checkConfig().checkId)}</div>
+        <div class="text-2xl mb-4">
+          Configure Check: {titleCase(checkConfig().checkId)}
+        </div>
 
         {check.parameters.length === 0 && (
           <div class="mb-4">This check has no configurable parameters.</div>
         )}
         {check.parameters.length > 0 && (
           <div class="mb-4">
-            <div class="text-lg font-bold mb-2">
-              Parameters
-            </div>
+            <div class="text-lg font-bold mb-2">Parameters</div>
             <div class="flex flex-col gap-4">
               <For each={check.parameters}>
                 {(parameter) => {
@@ -73,87 +80,124 @@ const ConfigureCheckModal = (
       </div>
     </div>
   );
-}
+};
 
-const ParameterInput = (
-  { tempCheck, setTempCheck, parameter }:
-  { tempCheck: Accessor<CheckConfig>; setTempCheck: SetStoreFunction<CheckConfig>, parameter: Accessor<ParameterDefinition> }
-) => {
+const ParameterInput = ({
+  tempCheck,
+  setTempCheck,
+  parameter,
+}: {
+  tempCheck: Accessor<CheckConfig>;
+  setTempCheck: SetStoreFunction<CheckConfig>;
+  parameter: Accessor<ParameterDefinition>;
+}) => {
   const parameterKey = () => parameter().key;
   const parameterType = () => parameter().type;
 
   const onParameterChange = (newValue: any) => {
-    setTempCheck(
-      "parameters", parameterKey(), newValue
-    );
-  }
+    setTempCheck("parameters", parameterKey(), newValue);
+  };
 
   if (parameter().type === "number") {
-    return <ParameterNumberInput onParameterChange={onParameterChange} parameter={parameter as Accessor<NumberParameter>} currentValue={() => tempCheck().parameters[parameterKey()]} />;
+    return (
+      <ParameterNumberInput
+        onParameterChange={onParameterChange}
+        parameter={parameter as Accessor<NumberParameter>}
+        currentValue={() => tempCheck().parameters[parameterKey()]}
+      />
+    );
   } else if (parameterType() === "string") {
-    return <ParameterStringInput onParameterChange={onParameterChange} parameter={parameter as Accessor<StringParameter>} currentValue={() => tempCheck().parameters[parameterKey()]} />;
+    return (
+      <ParameterStringInput
+        onParameterChange={onParameterChange}
+        parameter={parameter as Accessor<StringParameter>}
+        currentValue={() => tempCheck().parameters[parameterKey()]}
+      />
+    );
   } else if (parameterType() === "boolean") {
-    return <ParameterBooleanInput onParameterChange={onParameterChange} parameter={parameter as Accessor<BooleanParameter>} currentValue={() => tempCheck().parameters[parameterKey()]} />;
+    return (
+      <ParameterBooleanInput
+        onParameterChange={onParameterChange}
+        parameter={parameter as Accessor<BooleanParameter>}
+        currentValue={() => tempCheck().parameters[parameterKey()]}
+      />
+    );
   }
   return <div>Unsupported parameter type: {parameterType()}</div>;
-}
+};
 
-const ParameterNumberInput = (
-  { onParameterChange, parameter, currentValue }:
-  { onParameterChange: (value: any) => void, parameter: Accessor<NumberParameter>, currentValue: Accessor<any> }
-) => {
+const ParameterNumberInput = ({
+  onParameterChange,
+  parameter,
+  currentValue,
+}: {
+  onParameterChange: (value: any) => void;
+  parameter: Accessor<NumberParameter>;
+  currentValue: Accessor<any>;
+}) => {
   return (
     <div class="pl-2">
       <div class="mb-2 font-bold">
-        {titleCase(parameter().key)} {parameter().required && <span class="text-red-600">*</span>}
+        {titleCase(parameter().key)}{" "}
+        {parameter().required && <span class="text-red-600">*</span>}
       </div>
-      <div class="mb-2">
-        {parameter().label}
-      </div>
+      <div class="mb-2">{parameter().label}</div>
       <input
-        onInput={(e) => {onParameterChange(Number(e.target.value))}}
+        onInput={(e) => {
+          onParameterChange(Number(e.target.value));
+        }}
         value={currentValue()}
         type="number"
         class="form-input"
       />
     </div>
   );
-}
+};
 
-const ParameterStringInput = (
-  { onParameterChange, parameter, currentValue }:
-  { onParameterChange: (value: any) => void, parameter: Accessor<StringParameter>, currentValue: Accessor<any> }
-) => {
+const ParameterStringInput = ({
+  onParameterChange,
+  parameter,
+  currentValue,
+}: {
+  onParameterChange: (value: any) => void;
+  parameter: Accessor<StringParameter>;
+  currentValue: Accessor<any>;
+}) => {
   return (
     <div class="pl-2">
       <div class="mb-2 font-bold">
-        {titleCase(parameter().key)} {parameter().required && <span class="text-red-600">*</span>}
+        {titleCase(parameter().key)}{" "}
+        {parameter().required && <span class="text-red-600">*</span>}
       </div>
-      <div class="mb-2">
-        {parameter().label}
-      </div>
+      <div class="mb-2">{parameter().label}</div>
       <input
-        onInput={(e) => { onParameterChange(e.target.value); }}
+        onInput={(e) => {
+          onParameterChange(e.target.value);
+        }}
         type="text"
         value={currentValue() ?? ""}
         class="form-input"
       />
     </div>
   );
-}
+};
 
-const ParameterBooleanInput = (
-  { onParameterChange, parameter, currentValue }:
-  { onParameterChange: (value: any) => void, parameter: Accessor<BooleanParameter>, currentValue: Accessor<any> }
-) => {
+const ParameterBooleanInput = ({
+  onParameterChange,
+  parameter,
+  currentValue,
+}: {
+  onParameterChange: (value: any) => void;
+  parameter: Accessor<BooleanParameter>;
+  currentValue: Accessor<any>;
+}) => {
   return (
     <div class="pl-2">
       <div class="mb-2 font-bold">
-        {titleCase(parameter().key)} {parameter().required && <span class="text-red-600">*</span>}
+        {titleCase(parameter().key)}{" "}
+        {parameter().required && <span class="text-red-600">*</span>}
       </div>
-      <div class="mb-2">
-        {parameter().label}
-      </div>
+      <div class="mb-2">{parameter().label}</div>
       <div class="flex items-center gap-4">
         <div class="flex items-center gap-2">
           <input
@@ -175,13 +219,12 @@ const ParameterBooleanInput = (
           />
           False
         </div>
-        {
-          currentValue() === undefined &&
+        {currentValue() === undefined && (
           <span class="ml-2 text-gray-500">Not set</span>
-        }
+        )}
       </div>
     </div>
   );
-}
+};
 
 export default ConfigureCheckModal;

--- a/builder-frontend/src/types.ts
+++ b/builder-frontend/src/types.ts
@@ -18,6 +18,7 @@ export interface Benefit {
 // An EligibilityCheck, as configured by a particular Benefit
 export interface CheckConfig {
   checkId: string;
+  checkName: string;
   parameters: ParameterValues;
 }
 export interface ParameterValues {
@@ -37,12 +38,11 @@ export interface EligibilityCheckDetail extends EligibilityCheck {
 }
 
 // Check Input Types
-type InputDefinition = (
-  StringInput |
-  StringSelectInput |
-  NumberInput |
-  BooleanInput
-);
+type InputDefinition =
+  | StringInput
+  | StringSelectInput
+  | NumberInput
+  | BooleanInput;
 interface BaseInput {
   key: string;
   prompt: string;
@@ -63,13 +63,12 @@ interface BooleanInput extends BaseInput {
 }
 
 // Parameter Types
-export type ParameterDefinition = (
-  StringParameter |
+export type ParameterDefinition =
+  | StringParameter
   // StringSelectParameter |
   // StringMultiInputParameter |
-  NumberParameter |
-  BooleanParameter
-);
+  | NumberParameter
+  | BooleanParameter;
 interface BaseParameter {
   key: string;
   label: string;
@@ -94,14 +93,14 @@ export interface BooleanParameter extends BaseParameter {
 
 /* Screener Evaluation Results */
 export interface ScreenerResult {
-  [key: string]: BenefitResult
+  [key: string]: BenefitResult;
 }
 export interface BenefitResult {
   name: string;
   result: OptionalBoolean;
   check_results: {
     [key: string]: CheckResult;
-  }
+  };
 }
 interface CheckResult {
   name: string;


### PR DESCRIPTION
## Included Changes:

- Updated Screener Evaluation endpoint to align with changes to data model
- Update Screener Evaluation to allow for multiple decisions to exist in checks DMN. There now just must be at least one check that has a name which corresponds to the "name" attribute of the check. Which ever DMN decision element has the same name as the check is used as the the final result of the check.
- Added a "name" attribute to the CheckConfig class so that that could be displayed on the configure check modal


### Breaking change for any currently existing checks:
In order for checks be evaluated just by ID without having to also pass in the ownerId, I updated the location where check DMN is stored so that it is just one flat bucket that stores all checks instead of storing check DMN in user scoped sub directories. Since all of the check IDs are unique this extra file structure is not necessary and this really simplifies the evaluation logic. (No need to fetch the original Check record to get the ownerId, the CheckConfigs on the benefit is all that is needed).

This means the DMN of old checks will need to moved to the main /check directory in the bucket to be accessible. 