### PR TITLE
Created library check service

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/LibraryCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/LibraryCheckResource.java
@@ -1,0 +1,27 @@
+package org.acme.controller;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+        import jakarta.ws.rs.core.MediaType;
+import org.acme.model.domain.EligibilityCheck;
+import org.acme.service.LibraryApiMetadataService;
+
+import java.util.List;
+
+@Path("/api")
+@Produces(MediaType.APPLICATION_JSON)
+public class LibraryCheckResource {
+
+    @Inject
+    LibraryApiMetadataService libraryApiMetadataService;  // Inject the singleton bean
+
+    @GET
+    @Path("/library-checks")
+    public List<EligibilityCheck> getLibraryChecks(@QueryParam("module") String module) {
+        if (module != null) {
+            return libraryApiMetadataService.getByModule(module);
+        }
+        return libraryApiMetadataService.getAll();
+    }
+}
+

--- a/builder-api/src/main/java/org/acme/model/domain/EligibilityCheck.java
+++ b/builder-api/src/main/java/org/acme/model/domain/EligibilityCheck.java
@@ -2,6 +2,7 @@ package org.acme.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 
@@ -15,6 +16,7 @@ public class EligibilityCheck {
     private boolean isActive;
     private String dmnModel;
     private List<InputDefinition> inputs;
+    private JsonNode situation;
     private List<ParameterDefinition> parameters;
     private String ownerId;
     @JsonProperty("isPublic")
@@ -106,5 +108,13 @@ public class EligibilityCheck {
 
     public void setPublic(Boolean aPublic) {
         isPublic = aPublic;
+    }
+
+    public JsonNode getSituation() {
+        return situation;
+    }
+
+    public void setSituation(JsonNode situation) {
+        this.situation = situation;
     }
 }

--- a/builder-api/src/main/java/org/acme/service/LibraryApiMetadataService.java
+++ b/builder-api/src/main/java/org/acme/service/LibraryApiMetadataService.java
@@ -1,0 +1,62 @@
+package org.acme.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.acme.model.domain.EligibilityCheck;
+import org.acme.persistence.StorageService;
+import org.acme.persistence.FirestoreUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+
+@ApplicationScoped
+public class LibraryApiMetadataService {
+    @Inject
+    private StorageService storageService;
+
+    private List<EligibilityCheck> checks;
+
+    @PostConstruct
+    void init() {
+        try {
+
+            // Get path of most recent library schema json document
+            Optional<Map<String, Object>> configOpt = FirestoreUtils.getFirestoreDocById("system", "config");
+            if (configOpt.isEmpty()){
+                Log.error("Failed to load library api config");
+                return;
+            }
+            Map<String, Object> config = configOpt.get();
+            String schemaPath = config.get("latestJsonStoragePath").toString();
+            Optional<String> apiSchemaOpt = storageService.getStringFromStorage(schemaPath);
+            if (apiSchemaOpt.isEmpty()){
+                Log.error("Failed to load library api schema document");
+                return;
+            }
+            String apiSchemaJson = apiSchemaOpt.get();
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            checks = mapper.readValue(apiSchemaJson, new TypeReference<List<EligibilityCheck>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load library api metadata", e);
+        }
+    }
+
+    public List<EligibilityCheck> getAll() {
+        return checks;
+    }
+
+    public List<EligibilityCheck> getByModule(String module) {
+        return checks.stream()
+                .filter(e -> module.equals(e.getModule()))
+                .toList();
+    }
+}
+

--- a/scripts/import-documents.py
+++ b/scripts/import-documents.py
@@ -1,0 +1,70 @@
+import firebase_admin
+from firebase_admin import credentials, storage, firestore
+import json
+from datetime import datetime
+
+
+# -----------------------------------
+# INIT FIREBASE
+# -----------------------------------
+
+# Add path to service account credentials
+cred = credentials.Certificate()
+
+firebase_admin.initialize_app(cred, {
+    "storageBucket": "benefit-decision-toolkit-play.firebasestorage.app"
+})
+
+db = firestore.client()
+bucket = storage.bucket()
+
+
+def save_json_to_storage_and_update_firestore(json_string, firestore_doc_path):
+    """
+    Upload JSON string to Firebase Storage and update Firestore
+    with the storage path or download URL of the uploaded file.
+    """
+
+    # ---------------------
+    # Create filename
+    # Example: exported_2025-02-12_14-30-59.json
+    # ---------------------
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"LibraryApiSchemaExports/export_{timestamp}.json"
+
+    # ---------------------
+    # Upload to storage
+    # ---------------------
+    blob = bucket.blob(filename)
+    blob.upload_from_string(json_string, content_type="application/json")
+
+    # Get the storage path
+    storage_path = blob.name
+
+    # ---------------------
+    # Update Firestore
+    # ---------------------
+    doc_ref = db.document(firestore_doc_path)
+    doc_ref.set({
+        "latestJsonStoragePath": storage_path,
+        "updatedAt": firestore.SERVER_TIMESTAMP
+    }, merge=True)
+
+    print("Uploaded:", storage_path)
+    print("Firestore updated!")
+
+    return storage_path
+
+
+# -----------------------------------
+# Example usage
+# -----------------------------------
+if __name__ == "__main__":
+    with open("endpoint_inputs.json", "r") as f:
+        data = json.load(f)
+        json_string = json.dumps(data, indent=2)
+
+    save_json_to_storage_and_update_firestore(
+        json_string,
+        firestore_doc_path="system/config"   # Example document path
+    )


### PR DESCRIPTION
Feature:
Added script to import library api schema into firebase storage (Not yet setup to run as bash script in devbox)

Feature:
LibraryApiMetadataService created that returns this data as EligibilityCheckObjects

Feature:
A new controller to fetch these Library Eligibility checks

Additional notes
- This is initial work needed for listing, configuring, and evaluating library checks but this does not include that implementation
- This does not yet include library benefits, just library checks
- I added a new attribute to EligibilityCheck to hold the "Situation" which is a json representation of the inputs expected by the check. I think some future work is needed to consolidate how we represent inputs in the system in custom and library checks and make sure they are represented and stored consistently. Right not the Situation can be arbitrary JSON. I'm hoping to define a more specific class in the future. Or reuse and modify the existing InputDefenition class.