### PR TITLE
feat: Add Maven dep caching to CI/CD workflows

### DIFF
--- a/.github/workflows/deploy-builder-api.yml
+++ b/.github/workflows/deploy-builder-api.yml
@@ -43,6 +43,15 @@ jobs:
         with:
           enable-cache: true
 
+      # Cache Maven dependencies to speed up builds
+      - name: 'Cache Maven dependencies'
+        uses: 'actions/cache@v4'
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('builder-api/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # Configure Workload Identity Federation and generate an access token
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/deploy-library-api.yml
+++ b/.github/workflows/deploy-library-api.yml
@@ -37,6 +37,15 @@ jobs:
         with:
           enable-cache: true
 
+      # Cache Maven dependencies to speed up builds
+      - name: 'Cache Maven dependencies'
+        uses: 'actions/cache@v4'
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('library-api/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # Extract version from pom.xml (source of truth) using Maven
       - name: 'Extract version from pom.xml'
         id: extract_version


### PR DESCRIPTION
Add actions/cache@v4 to both library-api and builder-api deployment workflows
to cache Maven dependencies in ~/.m2/repository. This will significantly speed
up builds by avoiding re-downloading dependencies on every run.
