### PR TITLE
Archive EligibilityChecks

### DIFF
--- a/builder-api/src/main/java/org/acme/model/domain/EligibilityCheck.java
+++ b/builder-api/src/main/java/org/acme/model/domain/EligibilityCheck.java
@@ -13,15 +13,13 @@ public class EligibilityCheck {
     private String module;
     private String description;
     private String version;
-    private boolean isActive;
     private String dmnModel;
     private JsonNode inputDefinition;
     private List<ParameterDefinition> parameterDefinitions;
     private String ownerId;
-    @JsonProperty("isPublic")
-    private Boolean isPublic;
     // API endpoint for evaluating library checks
     private String path;
+    private Boolean isArchived;
 
     public String getId() {
         return this.id;
@@ -71,14 +69,6 @@ public class EligibilityCheck {
         this.version = version;
     }
 
-    public boolean isActive() {
-        return isActive;
-    }
-
-    public void setActive(boolean active) {
-        isActive = active;
-    }
-
     public List<ParameterDefinition> getParameterDefinitions() {
         return parameterDefinitions;
     }
@@ -95,14 +85,6 @@ public class EligibilityCheck {
         this.ownerId = ownerId;
     }
 
-    public Boolean getPublic() {
-        return isPublic;
-    }
-
-    public void setPublic(Boolean aPublic) {
-        isPublic = aPublic;
-    }
-
     public JsonNode getInputDefinition() {
         return inputDefinition;
     }
@@ -117,5 +99,13 @@ public class EligibilityCheck {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public Boolean getIsArchived() {
+        return isArchived != null ? isArchived : false;
+    }
+
+    public void setIsArchived(Boolean isArchived) {
+        this.isArchived = isArchived;
     }
 }

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -24,6 +24,8 @@ public interface EligibilityCheckRepository {
 
     Optional<EligibilityCheck> getWorkingCustomCheck(String userId, String checkId);
 
+    Optional<EligibilityCheck> getWorkingCustomCheck(String userId, String checkId, boolean includeArchived);
+
     Optional<EligibilityCheck> getPublishedCustomCheck(String userId, String checkId);
 
     String saveNewWorkingCustomCheck(EligibilityCheck check) throws Exception;

--- a/builder-frontend/src/api/check.ts
+++ b/builder-frontend/src/api/check.ts
@@ -245,3 +245,22 @@ export const publishCheck = async (
     throw error; // rethrow so you can handle it in your component if needed
   }
 };
+
+export const archiveCheck = async (checkId: string): Promise<void> => {
+  const url = apiUrl + `/custom-checks/${checkId}/archive`;
+  try {
+    const response = await authFetch(url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Archive failed with status: ${response.status}`);
+    }
+  } catch (error) {
+    console.error("Error archiving check:", error);
+    throw error;
+  }
+};

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
@@ -6,6 +6,7 @@ import CheckModal from "./modals/CheckModal";
 import eligibilityCheckResource from "./eligibilityCheckResource";
 
 import type { EligibilityCheck } from "@/types";
+import ConfirmationModal from "@/components/shared/ConfirmationModal";
 
 const EligibilityChecksList = () => {
   const { checks, actions, actionInProgress, initialLoadStatus } =
@@ -59,6 +60,14 @@ const EligibilityChecksList = () => {
           modalAction={actions.addNewCheck}
         />
       )}
+      {checkIdToRemove() && (
+        <ConfirmationModal
+          confirmationTitle="Archive Check"
+          confirmationText="Are you sure you want to archive this Eligibility Check? This action cannot be undone."
+          callback={() => actions.removeCheck(checkIdToRemove()!)}
+          closeModal={() => setCheckIdToRemove(null)}
+        />
+      )}
     </div>
   );
 };
@@ -107,7 +116,7 @@ const CheckCard = ({
               setCheckIdToRemove(eligibilityCheck.id);
             }}
           >
-            Remove
+            Archive
           </div>
         </div>
       </div>

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
@@ -2,7 +2,7 @@ import { createResource, createEffect, Accessor, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import type { EligibilityCheck } from "@/types";
-import { addCheck, fetchUserDefinedChecks } from "@/api/check";
+import { addCheck, archiveCheck, fetchUserDefinedChecks } from "@/api/check";
 
 export interface EligibilityCheckResource {
   checks: () => EligibilityCheck[];
@@ -46,10 +46,10 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
   const removeCheck = async (checkIdToRemove: string) => {
     setActionInProgress(true);
     try {
-      // await removeCustomBenefit(screenerId(), benefitIdToRemove); TODO
+      await archiveCheck(checkIdToRemove);
       await refetch();
     } catch (e) {
-      console.error("Failed to delete check", e);
+      console.error("Failed to archive check", e);
     }
     setActionInProgress(false);
   };


### PR DESCRIPTION
- Removed no-longer-needed isPublic and isActive values on EligibilityCheck.
- Added property isArchived to EligibilityChecks, which default to `false` if not set.
- Updated RemoveCheck button to archive EligibilityChecks.

Resolves:
https://github.com/CodeForPhilly/benefit-decision-toolkit/issues/220