### PR TITLE
Refactor: Rename QuestionTooltip to Tooltip with interactive popover support

### DIFF
--- a/builder-frontend/src/components/shared/Tooltip.tsx
+++ b/builder-frontend/src/components/shared/Tooltip.tsx
@@ -73,8 +73,13 @@ export default function QuestionTooltip(props: TooltipProps) {
       class="relative inline-flex items-center justify-center cursor-help"
       onMouseEnter={show}
       onMouseLeave={hide}
-      onFocus={show}
-      onBlur={hide}
+      onFocusIn={show}
+      onFocusOut={(e: FocusEvent) => {
+        // Only hide if focus is leaving the entire tooltip container
+        if (!containerRef?.contains(e.relatedTarget as Node)) {
+          hide();
+        }
+      }}
       tabIndex={0}
       aria-label="More information"
     >
@@ -91,8 +96,6 @@ export default function QuestionTooltip(props: TooltipProps) {
                 ? "left-0"
                 : "right-0"
           }`}
-          onMouseEnter={show}
-          onMouseLeave={hide}
         >
           {props.children}
           {/* Decorative arrow pointing up */}


### PR DESCRIPTION
### Summary

Refactors the tooltip component to support rich, interactive popover content (e.g. hyperlinks to documentation) instead of plain text only. The component API is redesigned so `children` serves as the popover content and an optional `label` prop customizes the trigger element.

Closes #348 

### Motivation

The previous `QuestionTooltip` component rendered tooltip text as a plain string via a `text` prop and applied `pointer-events-none` to the popover, making it impossible for users to click links inside it. We want to link users to relevant documentation sections directly from tooltip popovers.

### Changes

- **Renamed** `QuestionTooltip` → `Tooltip` (`Tooltip.tsx`)
- **Flipped the component API:**
  - `children` is now the popover content (accepts JSX links, formatted text, etc.)
  - `label?: JSX.Element` is the optional trigger element (defaults to `QuestionMarkIcon`)
  - Removed the old `text: string` prop
- **Made the popover interactive:**
  - Removed `pointer-events-none` from the popover
  - Added a 150ms hide delay so users can move their cursor from the trigger into the popover without it disappearing
  - Added `onCleanup` to clear pending hide timeouts on unmount
- **Keyboard accessibility:**
  - Replaced `onFocus`/`onBlur` with `onFocusIn`/`onFocusOut` using `relatedTarget` checking the popover stays open when tabbing to focusable elements (e.g. links) inside it, and only closes when focus leaves the entire tooltip container

### Usage

```tsx
{/* Basic — plain text content, default question-mark icon trigger */}
<Tooltip>
  Screener is another name for a project or tool.
</Tooltip>

{/* Rich content with a link */}
<Tooltip>
  Click here to securely end your session.
  <a href="https://bdt-docs.web.app/" target="_blank">Learn more</a>
</Tooltip>

{/* Custom trigger label */}
<Tooltip label={<span>ℹ️</span>}>
  Popover with a custom trigger icon.
</Tooltip>
```
### Screenshots
<img width="722" height="415" alt="image" src="https://github.com/user-attachments/assets/44cac052-1931-4172-86ce-bf8701316799" />
