### PR TITLE
chore: remove Thunder Client vestiges

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-  "thunder-client.saveToWorkspace": true,
-  "thunder-client.workspaceRelativePath": "library-api",
   "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx4G -Xms100m -Xlog:disable"
 }

--- a/library-api/CLAUDE.md
+++ b/library-api/CLAUDE.md
@@ -696,7 +696,7 @@ These are strictly enforced and violations will cause runtime errors:
 
 ### Bruno (Latest)
 
-- API testing tool (replaces Thunder Client, Postman)
+- API testing tool
 - Collection-based organization
 - Environment management
 - CLI for CI/CD: `bru run`


### PR DESCRIPTION
Closes #311

## Summary

Removes leftover Thunder Client references now that Bruno is the API testing tool for this project.

## Changes

- **`.vscode/settings.json`** — removed `thunder-client.saveToWorkspace` and `thunder-client.workspaceRelativePath`
- **`library-api/CLAUDE.md`** — removed stale `(replaces Thunder Client, Postman)` parenthetical from the Bruno entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)