### PR TITLE
Form editor: real-time input mapping panel with palette highlighting

### DIFF
--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -12,7 +12,7 @@ import Drawer from "@corvu/drawer"; // 'corvu/drawer'
 
 import CustomFormFieldsModule from "./formJsExtensions/customFormFields";
 import { customKeyModule } from './formJsExtensions/customKeyDropdown/customKeyDropdownProvider';
-import PathOptionsService, { pathOptionsModule } from './formJsExtensions/customKeyDropdown/pathOptionsService';
+import PathOptionsService, { compatibleComponentLabels, pathOptionsModule } from './formJsExtensions/customKeyDropdown/pathOptionsService';
 
 import { saveFormSchema, fetchFormPaths } from "../../api/screener";
 import { extractFormPaths } from "../../utils/formSchemaUtils";
@@ -226,8 +226,18 @@ const FormValidationDrawer = (
               my-auto rounded-lg
               text-lg font-medium transition-all duration-100 "
           >
-            <div class="btn-default btn-gray shadow-[0_0_10px_rgba(0,0,0,0.4)]">
-              Validate Form Outputs
+            <div class="btn-default btn-gray shadow-[0_0_10px_rgba(0,0,0,0.4)] flex items-center gap-2">
+              Required Inputs
+              <Show when={missingInputs().length > 0}>
+                <span class="bg-red-500 text-white text-xs font-bold rounded-full px-2 py-0.5">
+                  {missingInputs().length}
+                </span>
+              </Show>
+              <Show when={missingInputs().length === 0 && expectedInputs().length > 0}>
+                <span class="bg-green-500 text-white text-xs font-bold rounded-full px-2 py-0.5">
+                  ✓
+                </span>
+              </Show>
             </div>
           </Drawer.Trigger>
           <Drawer.Portal>
@@ -251,7 +261,7 @@ const FormValidationDrawer = (
                 data-transitioning:ease-[cubic-bezier(0.32,0.72,0,1)] overflow-y-scroll"
             >
               <Drawer.Label class="pt-5 mr-10 text-center text-xl font-bold">
-                Form Validation
+                Required Inputs
               </Drawer.Label>
 
               {/* Form Outputs Section */}
@@ -289,8 +299,11 @@ const FormValidationDrawer = (
                   }
                 >
                   {(formPath) => (
-                    <div class="py-2 px-3 mb-2 bg-red-50 rounded border border-red-300 font-mono text-sm text-red-800">
-                      {formPath.path} ({formPath.type})
+                    <div class="py-2 px-3 mb-2 bg-red-50 rounded border border-red-300 text-red-800">
+                      <div class="font-mono text-sm">{formPath.path}</div>
+                      <div class="text-xs text-red-600 mt-0.5">
+                        Use: {compatibleComponentLabels(formPath.type).join(", ")}
+                      </div>
                     </div>
                   )}
                 </For>

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -260,8 +260,8 @@ const InputPill = ({
     'cursor-pointer select-none',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500',
     isMissing
-      ? `${isPinned ? 'border-red-500' : 'border-red-300'} bg-red-50 text-red-800`
-      : `${isPinned ? 'border-green-500' : 'border-green-300'} bg-green-50 text-green-800`,
+      ? `border-red-300 ${isPinned ? 'bg-red-100' : 'bg-red-50'} text-red-800`
+      : `border-green-300 ${isPinned ? 'bg-green-100' : 'bg-green-50'} text-green-800`,
     isPinned
       ? isMissing
         ? 'ring-2 ring-offset-1 ring-red-400 shadow-md shadow-red-400/50'

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -263,7 +263,9 @@ const InputPill = ({
       ? 'border-red-300 bg-red-50 text-red-800'
       : 'border-green-300 bg-green-50 text-green-800',
     isPinned
-      ? isMissing ? 'ring-2 ring-offset-1 ring-red-400' : 'ring-2 ring-offset-1 ring-green-400'
+      ? isMissing
+        ? 'ring-2 ring-offset-1 ring-red-400 shadow-md shadow-red-400/50'
+        : 'ring-2 ring-offset-1 ring-green-400 shadow-md shadow-green-400/50'
       : '',
   ].filter(Boolean).join(' ');
 

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -25,7 +25,7 @@ import { FormPath } from "@/types";
 function FormEditorView({ formSchema, setFormSchema }) {
   const [isUnsaved, setIsUnsaved] = createSignal(false);
   const [isSaving, setIsSaving] = createSignal(false);
-  const [highlightedTypes, setHighlightedTypes] = createSignal<string[]>([]);
+  const [highlightedTypes, setHighlightedTypes] = createSignal<string[]>([], { equals: false });
   const params = useParams();
 
   // Fetch form paths from backend (replaces local transformation logic)
@@ -330,29 +330,30 @@ const InputsPanel = ({
   const missingInputs = () => expectedInputs().filter((p) => !formOutputSet().has(p.path));
   const mappedInputs = () => expectedInputs().filter((p) => formOutputSet().has(p.path));
 
-  // Hover takes precedence over pin; pin persists after mouse leave
-  createEffect(() => {
-    const activePath = hoveredPath() ?? pinnedPath();
-    if (!activePath) {
-      setHighlightedTypes([]);
-      return;
-    }
-    const formPath = expectedInputs().find((p) => p.path === activePath);
-    setHighlightedTypes(formPath ? (TYPE_COMPATIBILITY[formPath.type] ?? []) : []);
-  });
+  const highlight = (activePath: string | null) => {
+    const fp = activePath ? expectedInputs().find((p) => p.path === activePath) : null;
+    setHighlightedTypes(fp ? (TYPE_COMPATIBILITY[fp.type] ?? []) : []);
+  };
 
   const handleShowTooltip = (path: string, pos: TooltipPosition) => {
     setTooltipState({ path, ...pos });
     setHoveredPath(path);
+    highlight(path);
   };
 
   const handleHideTooltip = () => {
     setTooltipState(null);
     setHoveredPath(null);
+    // Restore highlight from pinned pill (if any) when hover ends
+    highlight(pinnedPath());
   };
 
-  const handleClick = (path: string) =>
-    setPinnedPath((p) => (p === path ? null : path));
+  const handleClick = (path: string) => {
+    const newPin = pinnedPath() === path ? null : path;
+    setPinnedPath(newPin);
+    // Hover takes precedence; otherwise drive highlight from the new pin state
+    highlight(hoveredPath() ?? newPin);
+  };
 
   const tooltipLabel = () => {
     const state = tooltipState();

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -256,11 +256,6 @@ const InputPill = (props: {
     isMissing()
       ? `border-red-300 ${props.isPinned ? 'bg-red-100' : 'bg-red-50'} text-red-800`
       : `border-green-300 ${props.isPinned ? 'bg-green-100' : 'bg-green-50'} text-green-800`,
-    props.isPinned
-      ? isMissing()
-        ? 'ring-2 ring-offset-1 ring-red-400 shadow-md shadow-red-400/50'
-        : 'ring-2 ring-offset-1 ring-green-400 shadow-md shadow-green-400/50'
-      : '',
   ].filter(Boolean).join(' ');
 
   const ariaLabel = () => isMissing()

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -4,6 +4,7 @@ import {
   For, Match, Show, Switch,
   Accessor,
 } from "solid-js";
+import { Portal } from "solid-js/web";
 import toast from "solid-toast";
 import { useParams } from "@solidjs/router";
 
@@ -71,7 +72,7 @@ function FormEditorView({ formSchema, setFormSchema }) {
 
     formEditor.on("changed", (e) => {
       setIsUnsaved(true);
-      setFormSchema(e.schema);
+      setFormSchema({ ...e.schema });
     });
 
     // Set default key to field ID when a new form field is added
@@ -149,40 +150,9 @@ function FormEditorView({ formSchema, setFormSchema }) {
   });
 
   // Highlight compatible palette fields when an input pill is hovered/pinned
-  const STYLE_ID = 'bdt-palette-highlight';
-  onCleanup(() => document.getElementById(STYLE_ID)?.remove());
-  createEffect(() => {
-    const types = highlightedTypes();
-    if (types.length === 0) {
-      const el = document.getElementById(STYLE_ID);
-      if (el) el.textContent = '';
-      return;
-    }
-
-    let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
-    if (!styleEl) {
-      styleEl = document.createElement('style');
-      styleEl.id = STYLE_ID;
-      document.head.appendChild(styleEl);
-    }
-
-    const compatibleSelectors = types
-      .map((t) => `.fjs-palette-field[data-field-type='${t}']`)
-      .join(', ');
-
-    styleEl.textContent = `
-      .fjs-palette-field {
-        opacity: 0.2;
-        transition: opacity 0.15s ease;
-      }
-      ${compatibleSelectors} {
-        opacity: 1 !important;
-        outline: 2px solid #0ea5e9;
-        outline-offset: 1px;
-        border-radius: 4px;
-      }
-    `;
-  });
+  const PALETTE_STYLE_ID = 'bdt-palette-highlight';
+  onCleanup(() => document.getElementById(PALETTE_STYLE_ID)?.remove());
+  createEffect(() => updatePaletteHighlight(highlightedTypes(), PALETTE_STYLE_ID));
 
   const handleSave = async () => {
     const projectId = params.projectId;
@@ -230,6 +200,116 @@ function FormEditorView({ formSchema, setFormSchema }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Palette highlight helper (module-level, no reactive dependencies)
+// ---------------------------------------------------------------------------
+
+function updatePaletteHighlight(types: string[], styleId: string) {
+  let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
+  if (types.length === 0) {
+    if (styleEl) styleEl.textContent = '';
+    return;
+  }
+  if (!styleEl) {
+    styleEl = document.createElement('style');
+    styleEl.id = styleId;
+    document.head.appendChild(styleEl);
+  }
+  const compatibleSelectors = types
+    .map((t) => `.fjs-palette-field[data-field-type='${t}']`)
+    .join(', ');
+  styleEl.textContent = `
+    .fjs-palette-field {
+      opacity: 0.2;
+      transition: opacity 0.15s ease;
+    }
+    ${compatibleSelectors} {
+      opacity: 1 !important;
+      outline: 2px solid #0ea5e9;
+      outline-offset: 1px;
+      border-radius: 4px;
+    }
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// InputPill — shared pill component for missing and mapped inputs
+// ---------------------------------------------------------------------------
+
+type TooltipPosition = { x: number; y: number };
+
+const InputPill = ({
+  formPath,
+  status,
+  isPinned,
+  onShowTooltip,
+  onHideTooltip,
+  onClick,
+}: {
+  formPath: FormPath;
+  status: 'missing' | 'mapped';
+  isPinned: boolean;
+  onShowTooltip: (path: string, pos: TooltipPosition) => void;
+  onHideTooltip: () => void;
+  onClick: (path: string) => void;
+}) => {
+  const isMissing = status === 'missing';
+
+  const pillClass = () => [
+    'flex items-center gap-1.5 px-2 py-1 rounded-md border text-xs font-mono',
+    'cursor-pointer select-none',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500',
+    isMissing
+      ? 'border-red-300 bg-red-50 text-red-800'
+      : 'border-green-300 bg-green-50 text-green-800',
+    isPinned
+      ? isMissing ? 'ring-2 ring-offset-1 ring-red-400' : 'ring-2 ring-offset-1 ring-green-400'
+      : '',
+  ].filter(Boolean).join(' ');
+
+  const ariaLabel = isMissing
+    ? `${formPath.path}: not yet mapped. Needs ${compatibleComponentLabels(formPath.type).join(' or ')}.`
+    : `${formPath.path}: mapped. Compatible with ${compatibleComponentLabels(formPath.type).join(' or ')}.`;
+
+  const handleInteract = (e: MouseEvent | FocusEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    onShowTooltip(formPath.path, { x: rect.left, y: rect.top });
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isPinned}
+      aria-label={ariaLabel}
+      class={pillClass()}
+      onMouseEnter={handleInteract}
+      onMouseLeave={onHideTooltip}
+      onFocus={handleInteract}
+      onBlur={onHideTooltip}
+      onClick={() => onClick(formPath.path)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(formPath.path);
+        }
+      }}
+    >
+      <span aria-hidden="true" class={isMissing ? 'text-red-400 font-sans' : 'text-green-600 font-sans'}>
+        {isMissing ? '✗' : '✓'}
+      </span>
+      {formPath.path}
+      <span aria-hidden="true" class={isMissing ? 'text-red-300 font-sans text-[10px] leading-none' : 'text-green-400 font-sans text-[10px] leading-none'}>
+        ⓘ
+      </span>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// InputsPanel
+// ---------------------------------------------------------------------------
+
 const InputsPanel = ({
   formSchema,
   expectedInputPaths,
@@ -241,15 +321,14 @@ const InputsPanel = ({
 }) => {
   const [hoveredPath, setHoveredPath] = createSignal<string | null>(null);
   const [pinnedPath, setPinnedPath] = createSignal<string | null>(null);
+  const [tooltipState, setTooltipState] = createSignal<{ path: string; x: number; y: number } | null>(null);
 
   const formOutputSet = () =>
     new Set(formSchema() ? extractFormPaths(formSchema()) : []);
 
   const expectedInputs = () => expectedInputPaths() || [];
-  const missingInputs = () =>
-    expectedInputs().filter((p) => !formOutputSet().has(p.path));
-  const mappedInputs = () =>
-    expectedInputs().filter((p) => formOutputSet().has(p.path));
+  const missingInputs = () => expectedInputs().filter((p) => !formOutputSet().has(p.path));
+  const mappedInputs = () => expectedInputs().filter((p) => formOutputSet().has(p.path));
 
   // Hover takes precedence over pin; pin persists after mouse leave
   createEffect(() => {
@@ -262,10 +341,25 @@ const InputsPanel = ({
     setHighlightedTypes(formPath ? (TYPE_COMPATIBILITY[formPath.type] ?? []) : []);
   });
 
-  const handleMouseEnter = (path: string) => setHoveredPath(path);
-  const handleMouseLeave = () => setHoveredPath(null);
+  const handleShowTooltip = (path: string, pos: TooltipPosition) => {
+    setTooltipState({ path, ...pos });
+    setHoveredPath(path);
+  };
+
+  const handleHideTooltip = () => {
+    setTooltipState(null);
+    setHoveredPath(null);
+  };
+
   const handleClick = (path: string) =>
     setPinnedPath((p) => (p === path ? null : path));
+
+  const tooltipLabel = () => {
+    const state = tooltipState();
+    if (!state) return '';
+    const fp = expectedInputs().find((p) => p.path === state.path);
+    return fp ? `Use: ${compatibleComponentLabels(fp.type).join(', ')}` : '';
+  };
 
   return (
     <div class="flex items-center gap-3 flex-1 min-w-0">
@@ -280,66 +374,52 @@ const InputsPanel = ({
       </Show>
 
       <Show when={expectedInputs().length > 0}>
-        <div class="flex items-center gap-2 overflow-x-auto flex-1 py-0.5 no-scrollbar">
+        {/* py-1.5 and px-0.5 give the pinned ring enough room to avoid clipping */}
+        <div class="flex items-center gap-2 overflow-x-auto flex-1 py-1.5 px-0.5 no-scrollbar">
           <For each={missingInputs()}>
             {(formPath) => (
-              <div class="group relative shrink-0">
-                <div
-                  role="button"
-                  tabIndex={0}
-                  aria-pressed={pinnedPath() === formPath.path}
-                  aria-label={`${formPath.path}: not yet mapped. Needs ${compatibleComponentLabels(formPath.type).join(" or ")}.`}
-                  class={`flex items-center gap-1.5 px-2 py-1 rounded-md border border-red-300 bg-red-50 text-red-800 text-xs font-mono cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500${pinnedPath() === formPath.path ? ' ring-2 ring-offset-1 ring-red-400' : ''}`}
-                  onMouseEnter={() => handleMouseEnter(formPath.path)}
-                  onMouseLeave={handleMouseLeave}
-                  onFocus={() => handleMouseEnter(formPath.path)}
-                  onBlur={handleMouseLeave}
-                  onClick={() => handleClick(formPath.path)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(formPath.path); } }}
-                >
-                  <span aria-hidden="true" class="text-red-400 font-sans">✗</span>
-                  {formPath.path}
-                  <span aria-hidden="true" class="text-red-300 font-sans text-[10px] leading-none">ⓘ</span>
-                </div>
-                <div
-                  role="tooltip"
-                  class="absolute bottom-full left-0 mb-2 px-2 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-10"
-                >
-                  Use: {compatibleComponentLabels(formPath.type).join(", ")}
-                </div>
-              </div>
+              <InputPill
+                formPath={formPath}
+                status="missing"
+                isPinned={pinnedPath() === formPath.path}
+                onShowTooltip={handleShowTooltip}
+                onHideTooltip={handleHideTooltip}
+                onClick={handleClick}
+              />
             )}
           </For>
           <For each={mappedInputs()}>
             {(formPath) => (
-              <div class="group relative shrink-0">
-                <div
-                  role="button"
-                  tabIndex={0}
-                  aria-pressed={pinnedPath() === formPath.path}
-                  aria-label={`${formPath.path}: mapped. Compatible with ${compatibleComponentLabels(formPath.type).join(" or ")}.`}
-                  class={`flex items-center gap-1.5 px-2 py-1 rounded-md border border-green-300 bg-green-50 text-green-800 text-xs font-mono cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500${pinnedPath() === formPath.path ? ' ring-2 ring-offset-1 ring-green-400' : ''}`}
-                  onMouseEnter={() => handleMouseEnter(formPath.path)}
-                  onMouseLeave={handleMouseLeave}
-                  onFocus={() => handleMouseEnter(formPath.path)}
-                  onBlur={handleMouseLeave}
-                  onClick={() => handleClick(formPath.path)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(formPath.path); } }}
-                >
-                  <span aria-hidden="true" class="text-green-600 font-sans">✓</span>
-                  {formPath.path}
-                  <span aria-hidden="true" class="text-green-400 font-sans text-[10px] leading-none">ⓘ</span>
-                </div>
-                <div
-                  role="tooltip"
-                  class="absolute bottom-full left-0 mb-2 px-2 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-10"
-                >
-                  Use: {compatibleComponentLabels(formPath.type).join(", ")}
-                </div>
-              </div>
+              <InputPill
+                formPath={formPath}
+                status="mapped"
+                isPinned={pinnedPath() === formPath.path}
+                onShowTooltip={handleShowTooltip}
+                onHideTooltip={handleHideTooltip}
+                onClick={handleClick}
+              />
             )}
           </For>
         </div>
+      </Show>
+
+      {/* Tooltip rendered via Portal to escape the overflow-x:auto clipping context */}
+      <Show when={tooltipState() !== null}>
+        <Portal>
+          <div
+            role="tooltip"
+            style={{
+              position: 'fixed',
+              left: `${tooltipState()?.x ?? 0}px`,
+              top: `${(tooltipState()?.y ?? 0) - 8}px`,
+              transform: 'translateY(-100%)',
+              'z-index': '9999',
+            }}
+            class="px-2 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap pointer-events-none"
+          >
+            {tooltipLabel()}
+          </div>
+        </Portal>
       </Show>
     </div>
   );

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -238,14 +238,7 @@ function updatePaletteHighlight(types: string[], styleId: string) {
 
 type TooltipPosition = { x: number; y: number };
 
-const InputPill = ({
-  formPath,
-  status,
-  isPinned,
-  onShowTooltip,
-  onHideTooltip,
-  onClick,
-}: {
+const InputPill = (props: {
   formPath: FormPath;
   status: 'missing' | 'mapped';
   isPinned: boolean;
@@ -253,55 +246,56 @@ const InputPill = ({
   onHideTooltip: () => void;
   onClick: (path: string) => void;
 }) => {
-  const isMissing = status === 'missing';
+  // Derive isMissing from props (not destructured) so status stays reactive
+  const isMissing = () => props.status === 'missing';
 
   const pillClass = () => [
     'flex items-center gap-1.5 px-2 py-1 rounded-md border text-xs font-mono',
     'cursor-pointer select-none',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500',
-    isMissing
-      ? `border-red-300 ${isPinned ? 'bg-red-100' : 'bg-red-50'} text-red-800`
-      : `border-green-300 ${isPinned ? 'bg-green-100' : 'bg-green-50'} text-green-800`,
-    isPinned
-      ? isMissing
+    isMissing()
+      ? `border-red-300 ${props.isPinned ? 'bg-red-100' : 'bg-red-50'} text-red-800`
+      : `border-green-300 ${props.isPinned ? 'bg-green-100' : 'bg-green-50'} text-green-800`,
+    props.isPinned
+      ? isMissing()
         ? 'ring-2 ring-offset-1 ring-red-400 shadow-md shadow-red-400/50'
         : 'ring-2 ring-offset-1 ring-green-400 shadow-md shadow-green-400/50'
       : '',
   ].filter(Boolean).join(' ');
 
-  const ariaLabel = isMissing
-    ? `${formPath.path}: not yet mapped. Needs ${compatibleComponentLabels(formPath.type).join(' or ')}.`
-    : `${formPath.path}: mapped. Compatible with ${compatibleComponentLabels(formPath.type).join(' or ')}.`;
+  const ariaLabel = () => isMissing()
+    ? `${props.formPath.path}: not yet mapped. Needs ${compatibleComponentLabels(props.formPath.type).join(' or ')}.`
+    : `${props.formPath.path}: mapped. Compatible with ${compatibleComponentLabels(props.formPath.type).join(' or ')}.`;
 
   const handleInteract = (e: MouseEvent | FocusEvent) => {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    onShowTooltip(formPath.path, { x: rect.left, y: rect.top });
+    props.onShowTooltip(props.formPath.path, { x: rect.left, y: rect.top });
   };
 
   return (
     <div
       role="button"
       tabIndex={0}
-      aria-pressed={isPinned}
-      aria-label={ariaLabel}
+      aria-pressed={props.isPinned}
+      aria-label={ariaLabel()}
       class={pillClass()}
       onMouseEnter={handleInteract}
-      onMouseLeave={onHideTooltip}
+      onMouseLeave={props.onHideTooltip}
       onFocus={handleInteract}
-      onBlur={onHideTooltip}
-      onClick={() => onClick(formPath.path)}
+      onBlur={props.onHideTooltip}
+      onClick={() => props.onClick(props.formPath.path)}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onClick(formPath.path);
+          props.onClick(props.formPath.path);
         }
       }}
     >
-      <span aria-hidden="true" class={isMissing ? 'text-red-400 font-sans' : 'text-green-600 font-sans'}>
-        {isMissing ? '✗' : '✓'}
+      <span aria-hidden="true" class={isMissing() ? 'text-red-400 font-sans' : 'text-green-600 font-sans'}>
+        {isMissing() ? '✗' : '✓'}
       </span>
-      {formPath.path}
-      <span aria-hidden="true" class={isMissing ? 'text-red-300 font-sans text-[10px] leading-none' : 'text-green-400 font-sans text-[10px] leading-none'}>
+      {props.formPath.path}
+      <span aria-hidden="true" class={isMissing() ? 'text-red-300 font-sans text-[10px] leading-none' : 'text-green-400 font-sans text-[10px] leading-none'}>
         ⓘ
       </span>
     </div>

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -8,11 +8,10 @@ import toast from "solid-toast";
 import { useParams } from "@solidjs/router";
 
 import { FormEditor } from "@bpmn-io/form-js-editor";
-import Drawer from "@corvu/drawer"; // 'corvu/drawer'
 
 import CustomFormFieldsModule from "./formJsExtensions/customFormFields";
 import { customKeyModule } from './formJsExtensions/customKeyDropdown/customKeyDropdownProvider';
-import PathOptionsService, { compatibleComponentLabels, pathOptionsModule } from './formJsExtensions/customKeyDropdown/pathOptionsService';
+import PathOptionsService, { compatibleComponentLabels, pathOptionsModule, TYPE_COMPATIBILITY } from './formJsExtensions/customKeyDropdown/pathOptionsService';
 
 import { saveFormSchema, fetchFormPaths } from "../../api/screener";
 import { extractFormPaths } from "../../utils/formSchemaUtils";
@@ -25,6 +24,7 @@ import { FormPath } from "@/types";
 function FormEditorView({ formSchema, setFormSchema }) {
   const [isUnsaved, setIsUnsaved] = createSignal(false);
   const [isSaving, setIsSaving] = createSignal(false);
+  const [highlightedTypes, setHighlightedTypes] = createSignal<string[]>([]);
   const params = useParams();
 
   // Fetch form paths from backend (replaces local transformation logic)
@@ -148,6 +148,42 @@ function FormEditorView({ formSchema, setFormSchema }) {
     }
   });
 
+  // Highlight compatible palette fields when an input pill is hovered/pinned
+  const STYLE_ID = 'bdt-palette-highlight';
+  onCleanup(() => document.getElementById(STYLE_ID)?.remove());
+  createEffect(() => {
+    const types = highlightedTypes();
+    if (types.length === 0) {
+      const el = document.getElementById(STYLE_ID);
+      if (el) el.textContent = '';
+      return;
+    }
+
+    let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = STYLE_ID;
+      document.head.appendChild(styleEl);
+    }
+
+    const compatibleSelectors = types
+      .map((t) => `.fjs-palette-field[data-field-type='${t}']`)
+      .join(', ');
+
+    styleEl.textContent = `
+      .fjs-palette-field {
+        opacity: 0.2;
+        transition: opacity 0.15s ease;
+      }
+      ${compatibleSelectors} {
+        opacity: 1 !important;
+        outline: 2px solid #0ea5e9;
+        outline-offset: 1px;
+        border-radius: 4px;
+      }
+    `;
+  });
+
   const handleSave = async () => {
     const projectId = params.projectId;
     const schema = formSchema();
@@ -163,12 +199,10 @@ function FormEditorView({ formSchema, setFormSchema }) {
       <Show when={formPaths.loading}>
         <Loading />
       </Show>
-      <div class="flex flex-row">
-        <div class="flex-8 overflow-auto">
-          <div class="h-full" ref={(el) => (container = el)} />
-        </div>
-        <div class="flex-1 border-l-4 border-l-gray-200">
-          <div class="flex flex-col p-10 gap-4 place-items-center">
+      <div class="flex flex-col min-h-0 flex-1">
+        <div class="flex items-start gap-4 px-4 py-3 border-b-4 border-gray-200 bg-gray-50">
+          <InputsPanel formSchema={formSchema} expectedInputPaths={formPaths} setHighlightedTypes={setHighlightedTypes} />
+          <div class="shrink-0 pt-1">
             <Switch>
               <Match when={isUnsaved()}>
                 <div onClick={handleSave} class="btn-default btn-yellow">
@@ -176,10 +210,7 @@ function FormEditorView({ formSchema, setFormSchema }) {
                 </div>
               </Match>
               <Match when={isSaving()}>
-                <div
-                  onClick={handleSave}
-                  class="btn-default btn-gray cursor-not-allowed"
-                >
+                <div onClick={handleSave} class="btn-default btn-gray cursor-not-allowed">
                   Saving...
                 </div>
               </Match>
@@ -191,149 +222,126 @@ function FormEditorView({ formSchema, setFormSchema }) {
             </Switch>
           </div>
         </div>
-        <FormValidationDrawer formSchema={formSchema} expectedInputPaths={formPaths} />
+        <div class="flex-1 overflow-auto min-h-0">
+          <div class="h-full" ref={(el) => (container = el)} />
+        </div>
       </div>
     </>
   );
 }
 
-const FormValidationDrawer = (
-  { formSchema, expectedInputPaths }:
-  {formSchema: any, expectedInputPaths: Accessor<FormPath[]>}
-) => {
-  const formOutputs = () =>
-    formSchema() ? extractFormPaths(formSchema()) : [];
+const InputsPanel = ({
+  formSchema,
+  expectedInputPaths,
+  setHighlightedTypes,
+}: {
+  formSchema: any;
+  expectedInputPaths: Accessor<FormPath[]>;
+  setHighlightedTypes: (types: string[]) => void;
+}) => {
+  const [hoveredPath, setHoveredPath] = createSignal<string | null>(null);
+  const [pinnedPath, setPinnedPath] = createSignal<string | null>(null);
 
-  // Expected inputs come directly from backend API
+  const formOutputSet = () =>
+    new Set(formSchema() ? extractFormPaths(formSchema()) : []);
+
   const expectedInputs = () => expectedInputPaths() || [];
-
-  // Compute which expected inputs are satisfied vs missing
-  const formOutputSet = () => new Set(formOutputs());
-
-  const satisfiedInputs = () =>
-    expectedInputs().filter((formPath) => formOutputSet().has(formPath.path));
-
   const missingInputs = () =>
-    expectedInputs().filter((formPath) => !formOutputSet().has(formPath.path));
+    expectedInputs().filter((p) => !formOutputSet().has(p.path));
+  const mappedInputs = () =>
+    expectedInputs().filter((p) => formOutputSet().has(p.path));
+
+  // Hover takes precedence over pin; pin persists after mouse leave
+  createEffect(() => {
+    const activePath = hoveredPath() ?? pinnedPath();
+    if (!activePath) {
+      setHighlightedTypes([]);
+      return;
+    }
+    const formPath = expectedInputs().find((p) => p.path === activePath);
+    setHighlightedTypes(formPath ? (TYPE_COMPATIBILITY[formPath.type] ?? []) : []);
+  });
+
+  const handleMouseEnter = (path: string) => setHoveredPath(path);
+  const handleMouseLeave = () => setHoveredPath(null);
+  const handleClick = (path: string) =>
+    setPinnedPath((p) => (p === path ? null : path));
 
   return (
-    <Drawer side="right">
-      {(props) => (
-        <>
-          <Drawer.Trigger
-            class="
-              fixed bottom-5 right-5
-              my-auto rounded-lg
-              text-lg font-medium transition-all duration-100 "
-          >
-            <div class="btn-default btn-gray shadow-[0_0_10px_rgba(0,0,0,0.4)] flex items-center gap-2">
-              Required Inputs
-              <Show when={missingInputs().length > 0}>
-                <span class="bg-red-500 text-white text-xs font-bold rounded-full px-2 py-0.5">
-                  {missingInputs().length}
-                </span>
-              </Show>
-              <Show when={missingInputs().length === 0 && expectedInputs().length > 0}>
-                <span class="bg-green-500 text-white text-xs font-bold rounded-full px-2 py-0.5">
-                  ✓
-                </span>
-              </Show>
-            </div>
-          </Drawer.Trigger>
-          <Drawer.Portal>
-            <Drawer.Overlay
-              class="
-                fixed inset-0 z-50
-                data-transitioning:transition-colors data-transitioning:duration-500
-                data-transitioning:ease-[cubic-bezier(0.32,0.72,0,1)]"
-              style={{
-                "background-color": `rgb(0 0 0 / ${
-                  0.5 * props.openPercentage
-                })`,
-              }}
-            />
-            <Drawer.Content
-              class="
-                fixed flex flex-col md:select-none
-                -right-10 bottom-0 z-50 px-5 h-full max-w-[500px] min-w-[500px]
-                bg-gray-100 border-l-4 border-gray-400 rounded-l-lg
-                data-transitioning:transition-transform data-transitioning:duration-500
-                data-transitioning:ease-[cubic-bezier(0.32,0.72,0,1)] overflow-y-scroll"
-            >
-              <Drawer.Label class="pt-5 mr-10 text-center text-xl font-bold">
-                Required Inputs
-              </Drawer.Label>
+    <div class="flex items-center gap-3 flex-1 min-w-0">
+      <span class="shrink-0 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+        Form Inputs
+      </span>
 
-              {/* Form Outputs Section */}
-              <div class="mt-4 mr-10 px-4 pb-10">
-                <h3 class="text-lg font-semibold text-gray-700 mb-2">
-                  Form Outputs
-                </h3>
-                <For
-                  each={formOutputs()}
-                  fallback={
-                    <p class="text-gray-500 italic text-sm">
-                      No form fields defined yet.
-                    </p>
-                  }
-                >
-                  {(path) => (
-                    <div class="py-2 px-3 mb-2 bg-white rounded border border-gray-300 font-mono text-sm">
-                      {path}
-                    </div>
-                  )}
-                </For>
-              </div>
+      <Show when={expectedInputs().length === 0}>
+        <span class="text-gray-400 italic text-sm">
+          No benefits configured. Add benefits to see required inputs.
+        </span>
+      </Show>
 
-              {/* Missing Inputs Section */}
-              <div class="mt-4 mr-10 px-4">
-                <h3 class="text-lg font-semibold text-red-900 mb-2">
-                  Missing Inputs
-                </h3>
-                <For
-                  each={missingInputs()}
-                  fallback={
-                    <p class="text-gray-500 italic text-sm">
-                      All required inputs are satisfied!
-                    </p>
-                  }
+      <Show when={expectedInputs().length > 0}>
+        <div class="flex items-center gap-2 overflow-x-auto flex-1 py-0.5 no-scrollbar">
+          <For each={missingInputs()}>
+            {(formPath) => (
+              <div class="group relative shrink-0">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={pinnedPath() === formPath.path}
+                  aria-label={`${formPath.path}: not yet mapped. Needs ${compatibleComponentLabels(formPath.type).join(" or ")}.`}
+                  class={`flex items-center gap-1.5 px-2 py-1 rounded-md border border-red-300 bg-red-50 text-red-800 text-xs font-mono cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500${pinnedPath() === formPath.path ? ' ring-2 ring-offset-1 ring-red-400' : ''}`}
+                  onMouseEnter={() => handleMouseEnter(formPath.path)}
+                  onMouseLeave={handleMouseLeave}
+                  onFocus={() => handleMouseEnter(formPath.path)}
+                  onBlur={handleMouseLeave}
+                  onClick={() => handleClick(formPath.path)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(formPath.path); } }}
                 >
-                  {(formPath) => (
-                    <div class="py-2 px-3 mb-2 bg-red-50 rounded border border-red-300 text-red-800">
-                      <div class="font-mono text-sm">{formPath.path}</div>
-                      <div class="text-xs text-red-600 mt-0.5">
-                        Use: {compatibleComponentLabels(formPath.type).join(", ")}
-                      </div>
-                    </div>
-                  )}
-                </For>
-              </div>
-
-              {/* Satisfied Inputs Section */}
-              <div class="mt-4 mr-10 px-4">
-                <h3 class="text-lg font-semibold text-green-900 mb-2">
-                  Satisfied Inputs
-                </h3>
-                <For
-                  each={satisfiedInputs()}
-                  fallback={
-                    <p class="text-gray-500 italic text-sm">
-                      No inputs satisfied yet.
-                    </p>
-                  }
+                  <span aria-hidden="true" class="text-red-400 font-sans">✗</span>
+                  {formPath.path}
+                  <span aria-hidden="true" class="text-red-300 font-sans text-[10px] leading-none">ⓘ</span>
+                </div>
+                <div
+                  role="tooltip"
+                  class="absolute bottom-full left-0 mb-2 px-2 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-10"
                 >
-                  {(formPath) => (
-                    <div class="py-2 px-3 mb-2 bg-green-50 rounded border border-green-300 font-mono text-sm text-green-800">
-                      {formPath.path} ({formPath.type})
-                    </div>
-                  )}
-                </For>
+                  Use: {compatibleComponentLabels(formPath.type).join(", ")}
+                </div>
               </div>
-            </Drawer.Content>
-          </Drawer.Portal>
-        </>
-      )}
-    </Drawer>
+            )}
+          </For>
+          <For each={mappedInputs()}>
+            {(formPath) => (
+              <div class="group relative shrink-0">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={pinnedPath() === formPath.path}
+                  aria-label={`${formPath.path}: mapped. Compatible with ${compatibleComponentLabels(formPath.type).join(" or ")}.`}
+                  class={`flex items-center gap-1.5 px-2 py-1 rounded-md border border-green-300 bg-green-50 text-green-800 text-xs font-mono cursor-pointer select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500${pinnedPath() === formPath.path ? ' ring-2 ring-offset-1 ring-green-400' : ''}`}
+                  onMouseEnter={() => handleMouseEnter(formPath.path)}
+                  onMouseLeave={handleMouseLeave}
+                  onFocus={() => handleMouseEnter(formPath.path)}
+                  onBlur={handleMouseLeave}
+                  onClick={() => handleClick(formPath.path)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(formPath.path); } }}
+                >
+                  <span aria-hidden="true" class="text-green-600 font-sans">✓</span>
+                  {formPath.path}
+                  <span aria-hidden="true" class="text-green-400 font-sans text-[10px] leading-none">ⓘ</span>
+                </div>
+                <div
+                  role="tooltip"
+                  class="absolute bottom-full left-0 mb-2 px-2 py-1.5 bg-gray-800 text-white text-xs rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-10"
+                >
+                  Use: {compatibleComponentLabels(formPath.type).join(", ")}
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
   );
 };
 

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -260,8 +260,8 @@ const InputPill = ({
     'cursor-pointer select-none',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-sky-500',
     isMissing
-      ? 'border-red-300 bg-red-50 text-red-800'
-      : 'border-green-300 bg-green-50 text-green-800',
+      ? `${isPinned ? 'border-red-500' : 'border-red-300'} bg-red-50 text-red-800`
+      : `${isPinned ? 'border-green-500' : 'border-green-300'} bg-green-50 text-green-800`,
     isPinned
       ? isMissing
         ? 'ring-2 ring-offset-1 ring-red-400 shadow-md shadow-red-400/50'

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/customKeyDropdownProvider.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/customKeyDropdownProvider.ts
@@ -75,8 +75,6 @@ function CustomKeyDropdown(props: any) {
     // Get the component type to filter compatible options
     const componentType = field.type || '';
 
-    console.log(componentType);
-
     // Get options from the injected service, passing current key to exclude from disabling
     const options = pathOptionsService?.getOptions(currentKey, componentType) || [];
 

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
@@ -5,7 +5,7 @@ interface PathOption {
   disabled?: boolean;
 }
 
-const TYPE_COMPATIBILITY: Record<string, string[]> = {
+export const TYPE_COMPATIBILITY: Record<string, string[]> = {
   // String types
   'string': ['textfield', 'textarea', 'select', 'radio', 'checklist', 'taglist'],
   // Number types
@@ -24,6 +24,29 @@ const TYPE_COMPATIBILITY: Record<string, string[]> = {
   // Fallback for any/unknown types - compatible with all
   'any': ['textfield', 'textarea', 'number', 'checkbox', 'select', 'radio', 'checklist', 'taglist', 'datetime', 'yes_no'],
 };
+
+/** Human-readable labels for Form-JS component types. */
+export const COMPONENT_TYPE_LABELS: Record<string, string> = {
+  textfield: "Text field",
+  textarea: "Text area",
+  number: "Number",
+  checkbox: "Checkbox",
+  yes_no: "Yes / No",
+  radio: "Radio buttons",
+  select: "Dropdown",
+  checklist: "Checklist",
+  taglist: "Tag list",
+  datetime: "Date picker",
+};
+
+/**
+ * Returns the compatible Form-JS component types for a given JSON Schema type,
+ * as human-readable labels.
+ */
+export function compatibleComponentLabels(schemaType: string): string[] {
+  const componentTypes = TYPE_COMPATIBILITY[schemaType] ?? [];
+  return componentTypes.map((t) => COMPONENT_TYPE_LABELS[t] ?? t);
+}
 
 interface EventBus {
   fire(event: string, payload: { options: PathOption[] }): void;

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
@@ -118,7 +118,6 @@ export default class PathOptionsService {
    */
   getOptions(currentFieldKey?: string, componentType?: string): PathOption[] {
     const usedKeys = this.getUsedKeys();
-    console.log(this.pathOptions);
 
     return this.pathOptions
       .filter(option => {

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
@@ -3,6 +3,8 @@ import { Accessor, createSignal, For, Show } from "solid-js";
 import ConfigureCheckModal from "./modals/ConfigureCheckModal";
 
 import { titleCase } from "@/utils/title_case";
+import { extractInputPaths } from "@/utils/formSchemaUtils";
+import { compatibleComponentLabels } from "@/components/project/formJsExtensions/customKeyDropdown/pathOptionsService";
 
 import type {
   CheckConfig,
@@ -60,9 +62,24 @@ const SelectedEligibilityCheck = ({
         <div class="pl-2 [&:has(+div)]:mb-2">
           {checkConfig().checkDescription}
         </div>
-        {
-          // Place to display information about expected inputs for check
-        }
+        <Show when={extractInputPaths(checkConfig().inputDefinition).length > 0}>
+          <div class="[&:has(+div)]:mb-2">
+            <div class="text-lg font-bold pl-2">Required Form Inputs</div>
+            <For each={extractInputPaths(checkConfig().inputDefinition)}>
+              {(input) => (
+                <div class="pl-4 py-1">
+                  <div class="flex gap-2 items-baseline">
+                    <div class="font-mono text-sm">{input.path}</div>
+                    <div class="text-xs text-gray-500">({input.type})</div>
+                  </div>
+                  <div class="text-xs text-gray-400 pl-2">
+                    Use: {compatibleComponentLabels(input.type).join(", ")}
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
         {checkConfig().parameterDefinitions &&
           checkConfig().parameterDefinitions.length > 0 && (
             <div class="[&:has(+div)]:mb-2">

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
@@ -3,7 +3,7 @@ import { Accessor, createSignal, For, Show } from "solid-js";
 import ConfigureCheckModal from "./modals/ConfigureCheckModal";
 
 import { titleCase } from "@/utils/title_case";
-import { extractInputPaths } from "@/utils/formSchemaUtils";
+import { extractInputPaths, transformInputDefinitionSchema } from "@/utils/formSchemaUtils";
 import { compatibleComponentLabels } from "@/components/project/formJsExtensions/customKeyDropdown/pathOptionsService";
 
 import type {
@@ -62,10 +62,10 @@ const SelectedEligibilityCheck = ({
         <div class="pl-2 [&:has(+div)]:mb-2">
           {checkConfig().checkDescription}
         </div>
-        <Show when={extractInputPaths(checkConfig().inputDefinition).length > 0}>
+        <Show when={extractInputPaths(transformInputDefinitionSchema(checkConfig().inputDefinition, checkConfig().parameters)).length > 0}>
           <div class="[&:has(+div)]:mb-2">
             <div class="text-lg font-bold pl-2">Required Form Inputs</div>
-            <For each={extractInputPaths(checkConfig().inputDefinition)}>
+            <For each={extractInputPaths(transformInputDefinitionSchema(checkConfig().inputDefinition, checkConfig().parameters))}>
               {(input) => (
                 <div class="pl-4 py-1">
                   <div class="flex gap-2 items-baseline">

--- a/builder-frontend/src/utils/formSchemaUtils.ts
+++ b/builder-frontend/src/utils/formSchemaUtils.ts
@@ -1,3 +1,55 @@
+import type { JSONSchema7 } from "json-schema";
+
+export interface InputPath {
+  path: string;
+  type: string;
+}
+
+/**
+ * Recursively flattens a JSONSchema7 inputDefinition into dot-separated
+ * { path, type } pairs. Types match the keys used in TYPE_COMPATIBILITY
+ * (e.g. "string", "number", "boolean", "date", "date-time", "array:string").
+ *
+ * @param schema - The JSONSchema7 inputDefinition from a CheckConfig
+ * @returns Array of { path, type } pairs for every leaf field
+ */
+export function extractInputPaths(schema: JSONSchema7 | undefined): InputPath[] {
+  if (!schema) return [];
+
+  const results: InputPath[] = [];
+
+  function resolveLeafType(node: JSONSchema7): string {
+    const type = Array.isArray(node.type) ? node.type[0] : node.type;
+    if (type === "string") {
+      if (node.format === "date") return "date";
+      if (node.format === "date-time") return "date-time";
+      if (node.format === "time") return "time";
+    }
+    return (type as string) || "string";
+  }
+
+  function traverse(node: JSONSchema7, prefix: string) {
+    if (node.type === "object" && node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        if (typeof value === "boolean") continue;
+        traverse(value, prefix ? `${prefix}.${key}` : key);
+      }
+    } else if (node.type === "array") {
+      const items = node.items;
+      let itemType = "string";
+      if (items && typeof items !== "boolean" && !Array.isArray(items)) {
+        itemType = resolveLeafType(items as JSONSchema7);
+      }
+      if (prefix) results.push({ path: prefix, type: `array:${itemType}` });
+    } else {
+      if (prefix) results.push({ path: prefix, type: resolveLeafType(node) });
+    }
+  }
+
+  traverse(schema, "");
+  return results;
+}
+
 interface FormComponent {
   type: string;
   key?: string;

--- a/builder-frontend/src/utils/formSchemaUtils.ts
+++ b/builder-frontend/src/utils/formSchemaUtils.ts
@@ -19,7 +19,9 @@ export function extractInputPaths(schema: JSONSchema7 | undefined): InputPath[] 
   const results: InputPath[] = [];
 
   function resolveLeafType(node: JSONSchema7): string {
-    const type = Array.isArray(node.type) ? node.type[0] : node.type;
+    const type = Array.isArray(node.type)
+      ? node.type.find((t) => t !== "null") ?? node.type[0]
+      : node.type;
     if (type === "string") {
       if (node.format === "date") return "date";
       if (node.format === "date-time") return "date-time";

--- a/builder-frontend/src/utils/formSchemaUtils.ts
+++ b/builder-frontend/src/utils/formSchemaUtils.ts
@@ -6,6 +6,82 @@ export interface InputPath {
 }
 
 /**
+ * Mirrors the backend InputSchemaService.transformInputDefinitionSchema.
+ * Applies the people-array → personId-keyed-object and enrollments-nesting
+ * transformations before path extraction, so paths match what the backend
+ * returns from /screener/{id}/form-paths.
+ *
+ * @param schema - Raw inputDefinition JSONSchema7 from a CheckConfig
+ * @param parameters - CheckConfig parameters (may contain personId / peopleIds)
+ * @returns Transformed schema suitable for extractInputPaths
+ */
+export function transformInputDefinitionSchema(
+  schema: JSONSchema7 | undefined,
+  parameters: Record<string, any> = {}
+): JSONSchema7 {
+  if (!schema) return {};
+
+  const personIds: string[] = [];
+  if (typeof parameters.personId === "string" && parameters.personId) {
+    personIds.push(parameters.personId);
+  }
+  if (Array.isArray(parameters.peopleIds)) {
+    for (const id of parameters.peopleIds) {
+      if (typeof id === "string" && id) personIds.push(id);
+    }
+  }
+
+  let result = _transformPeopleSchema(schema, personIds);
+  result = _transformEnrollmentsSchema(result, personIds);
+  return result;
+}
+
+function _transformPeopleSchema(schema: JSONSchema7, personIds: string[]): JSONSchema7 {
+  const props = schema.properties;
+  if (!props || !props.people || personIds.length === 0) return { ...schema };
+
+  const peopleSchema = props.people as JSONSchema7;
+  const itemsSchema = (peopleSchema.items as JSONSchema7) ?? {};
+
+  const newPeopleProps: Record<string, JSONSchema7> = {};
+  for (const id of personIds) {
+    newPeopleProps[id] = { ...itemsSchema };
+  }
+
+  return {
+    ...schema,
+    properties: { ...props, people: { type: "object", properties: newPeopleProps } },
+  };
+}
+
+function _transformEnrollmentsSchema(schema: JSONSchema7, personIds: string[]): JSONSchema7 {
+  const props = schema.properties;
+  if (!props || !props.enrollments || personIds.length === 0) return { ...schema };
+
+  const enrollmentsSchema: JSONSchema7 = { type: "array", items: { type: "string" } };
+  const { enrollments: _removed, people, ...restProps } = props as any;
+  const existingPeople = (people ?? { type: "object", properties: {} }) as JSONSchema7;
+  const existingPeopleProps = (existingPeople.properties ?? {}) as Record<string, JSONSchema7>;
+
+  const newPeopleProps: Record<string, JSONSchema7> = {};
+  for (const id of personIds) {
+    const existing = existingPeopleProps[id] ?? ({ type: "object", properties: {} } as JSONSchema7);
+    newPeopleProps[id] = {
+      ...existing,
+      properties: {
+        ...(existing.properties as Record<string, JSONSchema7> ?? {}),
+        enrollments: enrollmentsSchema,
+      },
+    };
+  }
+
+  return {
+    ...schema,
+    properties: { ...restProps, people: { ...existingPeople, properties: newPeopleProps } },
+  };
+}
+
+/**
  * Recursively flattens a JSONSchema7 inputDefinition into dot-separated
  * { path, type } pairs. Types match the keys used in TYPE_COMPATIBILITY
  * (e.g. "string", "number", "boolean", "date", "date-time", "array:string").


### PR DESCRIPTION
## What this does

While building a form for a screener, I ran into a frustrating UX gap: there was no way to see what data fields the benefits required, or which form component types were compatible, without leaving the Form Editor tab. This PR adds real-time visibility directly in the form editor toolbar.

## Changes

### Compact input status strip (top of Form Editor)
A horizontal pill bar replaces the previous hidden/drawer validation approach. It shows every required input path at a glance — no button click needed.

- **Red pill (✗)** — input path not yet mapped to any form field key
- **Green pill (✓)** — input path is covered by a field in the form

### Palette highlighting on hover/click
Hovering a pill dims incompatible component types in the left-hand palette and outlines compatible ones with a sky-blue ring — so you know exactly what to drag onto the canvas.

Clicking a pill **pins** the highlight so it stays visible while you work. Click again to unpin.

### Tooltip
A tooltip on each pill lists the compatible component types in human-readable form ("Text field", "Dropdown", etc.).

### ARIA / keyboard support
- `role="button"`, `tabIndex`, `aria-pressed` (pin state), `aria-label` (path + status + compatible types)
- Enter/Space activate the pin toggle
- Focus triggers the same palette highlight as hover
- `role="tooltip"` on tooltip divs; tooltip visible on `group-focus-within` as well as hover
- Decorative icon spans (`✗` `✓` `ⓘ`) marked `aria-hidden`

### Bug fix
`extractInputPaths` now correctly handles nullable JSON Schema union types (`["null", "string"]`) by skipping `"null"` before resolving the leaf type — previously it would take index 0, silently produce no compatible components for optional fields, and break the key dropdown filter.

### Cleanup
- Removed two stray `console.log` statements in `customKeyDropdownProvider` and `pathOptionsService`

## Screenshot

_Form editor showing the input strip with one missing input (red), two mapped inputs (green), and the boolean-compatible palette components highlighted after hovering `simpleChecks.tenYearTaxAbatement`:_

<!-- screenshot will be attached -->

## Testing

1. Create or open a screener with at least one benefit that has eligibility checks
2. Open **Form Editor** tab
3. Verify the **FORM INPUTS** strip appears above the canvas with red/green pills
4. Hover a pill → incompatible palette fields dim, compatible ones get a sky-blue outline
5. Click a pill → highlight pins (pill shows a ring); click again to unpin
6. Tab to a pill and press Enter/Space → same pin/unpin behaviour as click
7. Tab to a pill → tooltip appears and palette highlight activates without mouse