### PR TITLE
Make location lookups resilient against non-conformant data (#26)

### DIFF
--- a/builder-api/src/main/java/org/acme/functions/LocationService.java
+++ b/builder-api/src/main/java/org/acme/functions/LocationService.java
@@ -48,7 +48,20 @@ public class LocationService {
         return query(column, filters, "=");
     }
 
+    private static final java.util.Set<String> ALLOWED_COLUMNS = java.util.Set.of(
+            "zipCode", "countyName", "stateAbbreviation", "stateName"
+    );
+
     private static List<String> query(String column, Map<String, Object> filters, String operator) {
+        if (!ALLOWED_COLUMNS.contains(column)) {
+            throw new IllegalArgumentException("Invalid column: " + column);
+        }
+        for (String key : filters.keySet()) {
+            if (!ALLOWED_COLUMNS.contains(key)) {
+                throw new IllegalArgumentException("Invalid filter key: " + key);
+            }
+        }
+
         List<String> results = new ArrayList<>();
 
         StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");

--- a/builder-api/src/main/java/org/acme/functions/LocationService.java
+++ b/builder-api/src/main/java/org/acme/functions/LocationService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 @Unremovable
@@ -21,11 +22,14 @@ import java.util.logging.Logger;
 public class LocationService {
 
     private static final Logger LOG = Logger.getLogger(LocationService.class.getName());
+    private static final Set<String> ALLOWED_COLUMNS = Set.of(
+            "zipCode", "countyName", "countyFips", "stateAbbreviation"
+    );
 
     @Inject
     AgroalDataSource dataSource;
 
-    public Connection getDbConnection() throws SQLException {
+    Connection getDbConnection() throws SQLException {
         return dataSource.getConnection();
     }
 
@@ -37,7 +41,6 @@ public class LocationService {
         Map<String, Object> patterns = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : filters.entrySet()) {
             String raw = entry.getValue().toString().trim();
-            // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
             String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
             patterns.put(entry.getKey(), pattern);
         }
@@ -48,13 +51,12 @@ public class LocationService {
         return query(column, filters, "=");
     }
 
-    private static final java.util.Set<String> ALLOWED_COLUMNS = java.util.Set.of(
-            "zipCode", "countyName", "stateAbbreviation", "stateName"
-    );
-
     private static List<String> query(String column, Map<String, Object> filters, String operator) {
         if (!ALLOWED_COLUMNS.contains(column)) {
             throw new IllegalArgumentException("Invalid column: " + column);
+        }
+        if (filters.isEmpty()) {
+            throw new IllegalArgumentException("filters must not be empty");
         }
         for (String key : filters.keySet()) {
             if (!ALLOWED_COLUMNS.contains(key)) {

--- a/builder-api/src/main/java/org/acme/functions/LocationService.java
+++ b/builder-api/src/main/java/org/acme/functions/LocationService.java
@@ -11,12 +11,16 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 @Unremovable
 @ApplicationScoped
 public class LocationService {
+
+    private static final Logger LOG = Logger.getLogger(LocationService.class.getName());
 
     @Inject
     AgroalDataSource dataSource;
@@ -30,73 +34,50 @@ public class LocationService {
      * Trailing periods are stripped so abbreviations like "Mont." match "Montgomery".
      */
     public static List<String> lookupFuzzy(String column, Map<String, Object> filters) {
-        Map<String, Object> normalised = new java.util.LinkedHashMap<>();
+        Map<String, Object> patterns = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : filters.entrySet()) {
             String raw = entry.getValue().toString().trim();
             // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
             String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
-            normalised.put(entry.getKey(), pattern);
+            patterns.put(entry.getKey(), pattern);
         }
-        return lookupWithOperator(column, normalised, "LIKE ? COLLATE NOCASE");
+        return query(column, patterns, "LIKE");
     }
 
     public static List<String> lookup(String column, Map<String, Object> filters) {
-        return lookupWithOperator(column, filters, "= ? COLLATE NOCASE");
+        return query(column, filters, "=");
     }
 
-    private static List<String> lookupWithOperator(String column, Map<String, Object> filters, String operator) {
+    private static List<String> query(String column, Map<String, Object> filters, String operator) {
         List<String> results = new ArrayList<>();
-        StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
 
-        // construct WHERE clause; assume everything is ANDed together
+        StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
         boolean first = true;
         for (String key : filters.keySet()) {
-            if (!first) {
-                sql.append(" AND ");
-            }
-            sql.append(key).append(" ").append(operator);
+            if (!first) sql.append(" AND ");
+            sql.append(key).append(" ").append(operator).append(" ? COLLATE NOCASE");
             first = false;
         }
 
         LocationService service = Arc.container().instance(LocationService.class).get();
 
-        Connection connection = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
+        try (Connection connection = service.getDbConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql.toString())) {
 
-        try {
-            connection = service.getDbConnection();
-            pstmt = connection.prepareStatement(sql.toString());
-
-            // Set the values dynamically
             int index = 1;
             for (Object value : filters.values()) {
-                String stringValue = value.toString().trim(); // db only has strings
-                pstmt.setString(index++, stringValue);
+                pstmt.setString(index++, value.toString().trim());
             }
 
-            rs = pstmt.executeQuery();
-
-            while(rs.next()) {
-                String thisString = rs.getString(column);
-                results.add(thisString);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(rs.getString(column));
+                }
             }
+
         } catch (SQLException e) {
-            e.printStackTrace();
-        } finally {
-            try {
-                if (rs != null) {
-                    rs.close();
-                }
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-                if (connection != null) {
-                    connection.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
+            LOG.severe("Location lookup failed for column=" + column + " filters=" + filters + ": " + e.getMessage());
+            throw new RuntimeException("Location lookup failed", e);
         }
 
         return results;

--- a/builder-api/src/main/java/org/acme/functions/LocationService.java
+++ b/builder-api/src/main/java/org/acme/functions/LocationService.java
@@ -25,7 +25,26 @@ public class LocationService {
         return dataSource.getConnection();
     }
 
+    /**
+     * Like {@link #lookup}, but matches filter values as case-insensitive prefix patterns.
+     * Trailing periods are stripped so abbreviations like "Mont." match "Montgomery".
+     */
+    public static List<String> lookupFuzzy(String column, Map<String, Object> filters) {
+        Map<String, Object> normalised = new java.util.LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : filters.entrySet()) {
+            String raw = entry.getValue().toString().trim();
+            // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
+            String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
+            normalised.put(entry.getKey(), pattern);
+        }
+        return lookupWithOperator(column, normalised, "LIKE ? COLLATE NOCASE");
+    }
+
     public static List<String> lookup(String column, Map<String, Object> filters) {
+        return lookupWithOperator(column, filters, "= ? COLLATE NOCASE");
+    }
+
+    private static List<String> lookupWithOperator(String column, Map<String, Object> filters, String operator) {
         List<String> results = new ArrayList<>();
         StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
 
@@ -35,7 +54,7 @@ public class LocationService {
             if (!first) {
                 sql.append(" AND ");
             }
-            sql.append(key).append(" = ?");
+            sql.append(key).append(" ").append(operator);
             first = false;
         }
 
@@ -52,7 +71,7 @@ public class LocationService {
             // Set the values dynamically
             int index = 1;
             for (Object value : filters.values()) {
-                String stringValue = value.toString(); // db only has strings
+                String stringValue = value.toString().trim(); // db only has strings
                 pstmt.setString(index++, stringValue);
             }
 
@@ -81,6 +100,5 @@ public class LocationService {
         }
 
         return results;
-
     }
 }

--- a/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
+++ b/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
@@ -24,7 +24,26 @@ public class LocationService {
         return dataSource.getConnection();
     }
 
+    /**
+     * Like {@link #lookup}, but matches filter values as case-insensitive prefix patterns.
+     * Trailing periods are stripped so abbreviations like "Mont." match "Montgomery".
+     */
+    public static List<String> lookupFuzzy(String column, Map<String, Object> filters) {
+        Map<String, Object> normalised = new java.util.LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : filters.entrySet()) {
+            String raw = entry.getValue().toString().trim();
+            // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
+            String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
+            normalised.put(entry.getKey(), pattern);
+        }
+        return lookupWithOperator(column, normalised, "LIKE ? COLLATE NOCASE");
+    }
+
     public static List<String> lookup(String column, Map<String, Object> filters) {
+        return lookupWithOperator(column, filters, "= ? COLLATE NOCASE");
+    }
+
+    private static List<String> lookupWithOperator(String column, Map<String, Object> filters, String operator) {
         List<String> results = new ArrayList<>();
         StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
 
@@ -34,7 +53,7 @@ public class LocationService {
             if (!first) {
                 sql.append(" AND ");
             }
-            sql.append(key).append(" = ?");
+            sql.append(key).append(" ").append(operator);
             first = false;
         }
 
@@ -44,14 +63,14 @@ public class LocationService {
         PreparedStatement pstmt = null;
         ResultSet rs = null;
 
-        try { 
+        try {
             connection = service.getDbConnection();
             pstmt = connection.prepareStatement(sql.toString());
 
             // Set the values dynamically
             int index = 1;
             for (Object value : filters.values()) {
-                String stringValue = value.toString(); // db only has strings
+                String stringValue = value.toString().trim(); // db only has strings
                 pstmt.setString(index++, stringValue);
             }
 
@@ -80,6 +99,5 @@ public class LocationService {
         }
 
         return results;
-            
-    }    
+    }
 }

--- a/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
+++ b/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
@@ -47,7 +47,20 @@ public class LocationService {
         return query(column, filters, "=");
     }
 
+    private static final java.util.Set<String> ALLOWED_COLUMNS = java.util.Set.of(
+            "zipCode", "countyName", "stateAbbreviation", "stateName"
+    );
+
     private static List<String> query(String column, Map<String, Object> filters, String operator) {
+        if (!ALLOWED_COLUMNS.contains(column)) {
+            throw new IllegalArgumentException("Invalid column: " + column);
+        }
+        for (String key : filters.keySet()) {
+            if (!ALLOWED_COLUMNS.contains(key)) {
+                throw new IllegalArgumentException("Invalid filter key: " + key);
+            }
+        }
+
         List<String> results = new ArrayList<>();
 
         StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");

--- a/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
+++ b/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 @Unremovable
@@ -20,11 +21,14 @@ import java.util.logging.Logger;
 public class LocationService {
 
     private static final Logger LOG = Logger.getLogger(LocationService.class.getName());
+    private static final Set<String> ALLOWED_COLUMNS = Set.of(
+            "zipCode", "countyName", "countyFips", "stateAbbreviation"
+    );
 
     @Inject
     AgroalDataSource dataSource;
 
-    public Connection getDbConnection() throws SQLException {
+    Connection getDbConnection() throws SQLException {
         return dataSource.getConnection();
     }
 
@@ -36,7 +40,6 @@ public class LocationService {
         Map<String, Object> patterns = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : filters.entrySet()) {
             String raw = entry.getValue().toString().trim();
-            // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
             String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
             patterns.put(entry.getKey(), pattern);
         }
@@ -47,13 +50,12 @@ public class LocationService {
         return query(column, filters, "=");
     }
 
-    private static final java.util.Set<String> ALLOWED_COLUMNS = java.util.Set.of(
-            "zipCode", "countyName", "stateAbbreviation", "stateName"
-    );
-
     private static List<String> query(String column, Map<String, Object> filters, String operator) {
         if (!ALLOWED_COLUMNS.contains(column)) {
             throw new IllegalArgumentException("Invalid column: " + column);
+        }
+        if (filters.isEmpty()) {
+            throw new IllegalArgumentException("filters must not be empty");
         }
         for (String key : filters.keySet()) {
             if (!ALLOWED_COLUMNS.contains(key)) {

--- a/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
+++ b/library-api/src/main/java/org/codeforphilly/bdt/functions/LocationService.java
@@ -10,12 +10,16 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 @Unremovable
 @ApplicationScoped
 public class LocationService {
+
+    private static final Logger LOG = Logger.getLogger(LocationService.class.getName());
 
     @Inject
     AgroalDataSource dataSource;
@@ -29,73 +33,50 @@ public class LocationService {
      * Trailing periods are stripped so abbreviations like "Mont." match "Montgomery".
      */
     public static List<String> lookupFuzzy(String column, Map<String, Object> filters) {
-        Map<String, Object> normalised = new java.util.LinkedHashMap<>();
+        Map<String, Object> patterns = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : filters.entrySet()) {
             String raw = entry.getValue().toString().trim();
             // Strip trailing period so "Mont." becomes "Mont%" for LIKE matching
             String pattern = raw.endsWith(".") ? raw.substring(0, raw.length() - 1) + "%" : raw + "%";
-            normalised.put(entry.getKey(), pattern);
+            patterns.put(entry.getKey(), pattern);
         }
-        return lookupWithOperator(column, normalised, "LIKE ? COLLATE NOCASE");
+        return query(column, patterns, "LIKE");
     }
 
     public static List<String> lookup(String column, Map<String, Object> filters) {
-        return lookupWithOperator(column, filters, "= ? COLLATE NOCASE");
+        return query(column, filters, "=");
     }
 
-    private static List<String> lookupWithOperator(String column, Map<String, Object> filters, String operator) {
+    private static List<String> query(String column, Map<String, Object> filters, String operator) {
         List<String> results = new ArrayList<>();
-        StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
 
-        // construct WHERE clause; assume everything is ANDed together
+        StringBuilder sql = new StringBuilder("SELECT DISTINCT ").append(column).append(" FROM locations WHERE ");
         boolean first = true;
         for (String key : filters.keySet()) {
-            if (!first) {
-                sql.append(" AND ");
-            }
-            sql.append(key).append(" ").append(operator);
+            if (!first) sql.append(" AND ");
+            sql.append(key).append(" ").append(operator).append(" ? COLLATE NOCASE");
             first = false;
         }
 
         LocationService service = Arc.container().instance(LocationService.class).get();
 
-        Connection connection = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
+        try (Connection connection = service.getDbConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql.toString())) {
 
-        try {
-            connection = service.getDbConnection();
-            pstmt = connection.prepareStatement(sql.toString());
-
-            // Set the values dynamically
             int index = 1;
             for (Object value : filters.values()) {
-                String stringValue = value.toString().trim(); // db only has strings
-                pstmt.setString(index++, stringValue);
+                pstmt.setString(index++, value.toString().trim());
             }
 
-            rs = pstmt.executeQuery();
-
-            while(rs.next()) {
-                String thisString = rs.getString(column);
-                results.add(thisString);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(rs.getString(column));
+                }
             }
+
         } catch (SQLException e) {
-            e.printStackTrace();
-        } finally {
-            try {
-                if (rs != null) {
-                    rs.close();
-                }
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-                if (connection != null) {
-                    connection.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
+            LOG.severe("Location lookup failed for column=" + column + " filters=" + filters + ": " + e.getMessage());
+            throw new RuntimeException("Location lookup failed", e);
         }
 
         return results;

--- a/library-api/src/test/java/org/codeforphilly/bdt/functions/LocationServiceTest.java
+++ b/library-api/src/test/java/org/codeforphilly/bdt/functions/LocationServiceTest.java
@@ -1,0 +1,107 @@
+package org.codeforphilly.bdt.functions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class LocationServiceTest {
+
+    // --- lookup() ---
+
+    @Test
+    public void testLookupExactMatch() {
+        List<String> results = LocationService.lookup("countyName", Map.of("zipCode", "19107"));
+        assertFalse(results.isEmpty(), "Should find a county for zip 19107");
+        assertTrue(results.contains("Philadelphia"));
+    }
+
+    @Test
+    public void testLookupCaseInsensitiveFilterValue() {
+        List<String> uppercase = LocationService.lookup("zipCode", Map.of("stateAbbreviation", "PA", "countyName", "Philadelphia"));
+        List<String> lowercase = LocationService.lookup("zipCode", Map.of("stateAbbreviation", "pa", "countyName", "philadelphia"));
+        assertFalse(uppercase.isEmpty(), "Exact case should return results");
+        assertEquals(uppercase.size(), lowercase.size(),
+                "Lowercase filter values should return same number of results as title-case");
+        assertTrue(lowercase.containsAll(uppercase));
+    }
+
+    @Test
+    public void testLookupCaseInsensitiveMixedCase() {
+        List<String> titleCase = LocationService.lookup("zipCode", Map.of("stateAbbreviation", "PA", "countyName", "Philadelphia"));
+        List<String> upperCase = LocationService.lookup("zipCode", Map.of("stateAbbreviation", "PA", "countyName", "PHILADELPHIA"));
+        assertEquals(titleCase.size(), upperCase.size(),
+                "UPPERCASE filter value should return same results as title-case");
+    }
+
+    @Test
+    public void testLookupTrimsLeadingWhitespace() {
+        List<String> trimmed   = LocationService.lookup("countyName", Map.of("zipCode", "19107"));
+        List<String> withSpace = LocationService.lookup("countyName", Map.of("zipCode", "  19107"));
+        assertEquals(trimmed, withSpace, "Leading whitespace on filter value should be trimmed");
+    }
+
+    @Test
+    public void testLookupTrimsTrailingWhitespace() {
+        List<String> trimmed   = LocationService.lookup("countyName", Map.of("zipCode", "19107"));
+        List<String> withSpace = LocationService.lookup("countyName", Map.of("zipCode", "19107  "));
+        assertEquals(trimmed, withSpace, "Trailing whitespace on filter value should be trimmed");
+    }
+
+    @Test
+    public void testLookupReturnsEmptyForNoMatch() {
+        List<String> results = LocationService.lookup("countyName", Map.of("stateAbbreviation", "ZZ"));
+        assertTrue(results.isEmpty(), "Unknown state abbreviation should return an empty list");
+    }
+
+    // --- lookupFuzzy() ---
+
+    @Test
+    public void testLookupFuzzyAbbreviationWithPeriod() {
+        // "Mont." should match both "Montgomery" and "Montour" in PA
+        List<String> results = LocationService.lookupFuzzy("countyName",
+                Map.of("countyName", "Mont.", "stateAbbreviation", "PA"));
+        assertFalse(results.isEmpty(), "Abbreviated 'Mont.' should match counties starting with 'Mont'");
+        assertTrue(results.contains("Montgomery"),
+                "Expected 'Montgomery' in fuzzy results for 'Mont.'");
+    }
+
+    @Test
+    public void testLookupFuzzyPrefixNoTrailingPeriod() {
+        // "Los" should match "Los Angeles" and other "Los ..." counties
+        List<String> results = LocationService.lookupFuzzy("countyName",
+                Map.of("countyName", "Los"));
+        assertFalse(results.isEmpty(), "Prefix 'Los' should match counties starting with 'Los'");
+        assertTrue(results.stream().allMatch(name -> name.toLowerCase().startsWith("los")),
+                "All results should start with 'Los'");
+    }
+
+    @Test
+    public void testLookupFuzzyIsCaseInsensitive() {
+        List<String> upper = LocationService.lookupFuzzy("countyName",
+                Map.of("countyName", "PHILA", "stateAbbreviation", "PA"));
+        List<String> lower = LocationService.lookupFuzzy("countyName",
+                Map.of("countyName", "phila", "stateAbbreviation", "PA"));
+        assertEquals(upper.size(), lower.size(),
+                "Fuzzy lookup should be case-insensitive");
+        assertTrue(lower.containsAll(upper));
+    }
+
+    @Test
+    public void testLookupFuzzyTrimsWhitespace() {
+        List<String> trimmed   = LocationService.lookupFuzzy("countyName", Map.of("countyName", "Phila", "stateAbbreviation", "PA"));
+        List<String> withSpace = LocationService.lookupFuzzy("countyName", Map.of("countyName", "  Phila  ", "stateAbbreviation", "PA"));
+        assertEquals(trimmed, withSpace, "Fuzzy lookup should trim whitespace before matching");
+    }
+
+    @Test
+    public void testLookupFuzzyReturnsEmptyForNoMatch() {
+        List<String> results = LocationService.lookupFuzzy("countyName",
+                Map.of("countyName", "ZZZZZ"));
+        assertTrue(results.isEmpty(), "Fuzzy lookup should return empty list when nothing matches");
+    }
+}

--- a/library-api/src/test/resources/application.properties
+++ b/library-api/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+# Use a random port so tests don't conflict with other running services
+quarkus.http.test-port=0


### PR DESCRIPTION
Closes #26

## Summary

- **Case-insensitive matching**: All lookups now use `COLLATE NOCASE` so `"montgomery"`, `"MONTGOMERY"`, and `"Montgomery"` all return the same results.
- **Whitespace trimming**: Filter values are trimmed before the query, so `"Montgomery "` and `"  Montgomery"` work correctly.
- **Fuzzy prefix matching**: New `lookupFuzzy()` method uses SQL `LIKE` with a `%` suffix so abbreviations like `"Mont."` match `"Montgomery"` and `"Montour"`. Trailing periods are stripped before the wildcard is appended.
- **SQL injection guard**: Column names and filter keys are now validated against an allowlist of known `locations` table columns (`zipCode`, `countyName`, `countyFips`, `stateAbbreviation`) before being interpolated into SQL. Filter values were already parameterized.
- **Error handling**: Replaced silent `e.printStackTrace()` with a structured log + `RuntimeException` so failures surface instead of returning empty results unexpectedly.
- **Resource management**: Replaced manual null-guarded `try/finally` blocks with try-with-resources for `Connection`, `PreparedStatement`, and `ResultSet`.
- **Tests**: Added 11 `@QuarkusTest` tests covering exact match, case-insensitive variants, whitespace trimming, empty result, and all fuzzy matching cases. Also fixed a pre-existing test port conflict (`quarkus.http.test-port=0`) that was causing all existing tests to be silently skipped in local dev when another service occupied port 8081. All 25 tests pass.

Changes applied to both `library-api` and `builder-api` copies of `LocationService`.

## Manual testing note

No checks currently call `LocationService`, so there is no end-to-end path to exercise this through the screener UI. **Residence checks would be the natural place to wire this in** — for example, a "lives in county X" check that looks up whether a ZIP code falls within a given county. That work is out of scope for this PR but would be needed to validate the feature manually.

## Test plan

- [x] `cd library-api && mvn test` — all 25 tests pass
- [ ] Add a residence check that calls `LocationService.lookup()` or `LocationService.lookupFuzzy()` and verify results in the screener UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)