### PR TITLE
Website form email

### DIFF
--- a/website/src/components/Contact.astro
+++ b/website/src/components/Contact.astro
@@ -10,7 +10,11 @@ import wedge from "../assets/backgrounds/wedge.svg";
         <div class="prose prose-headings:text-left">
           <Content />
         </div>
-        <form action="https://formspree.io/f/xlgpngrj" class="mt-6">
+        <form
+          action="https://formspree.io/f/xlgpngrj"
+          method="post"
+          class="mt-6"
+        >
           <div><label for="name">Name:</label></div>
           <div>
             <input


### PR DESCRIPTION
set up the contact form on the website to send an email to contact@bdtoolkit.org via Formspree