### PR TITLE
feat(seed-data): Add export-example-screener script

### DIFF
--- a/bin/export-emulator-data.py
+++ b/bin/export-emulator-data.py
@@ -1,0 +1,219 @@
+"""
+Export Firestore and Cloud Storage data from running Firebase emulators
+into a portable format suitable for seeding other environments (including production).
+
+Usage:
+  python3 bin/export-emulator-data.py [output-dir] [--skip-storage-prefix PREFIX ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import firebase_admin
+from firebase_admin import credentials, firestore, storage
+from google.cloud.firestore import Client as FirestoreClient
+from google.cloud.firestore_v1.base_document import DocumentSnapshot
+from google.cloud.storage import Bucket
+import google.auth.credentials
+
+
+# ---------------------------------------------------------------------------
+# Emulator credentials (same pattern as load-library-metadata.py)
+# ---------------------------------------------------------------------------
+
+class EmulatorCredentials(credentials.Base):
+    """Mock credentials for use with Firebase emulators."""
+    _mock_credential: google.auth.credentials.Credentials
+
+    def __init__(self) -> None:
+        self._mock_credential = google.auth.credentials.AnonymousCredentials()
+
+    def get_credential(self) -> google.auth.credentials.Credentials:
+        return self._mock_credential
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser(description="Export Firebase emulator data")
+parser.add_argument("output_dir", nargs="?",
+                    default="exported-data-" + datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+                    help="Output directory (default: timestamped directory)")
+parser.add_argument("--skip-storage-prefix", action="append", default=[],
+                    metavar="PREFIX",
+                    help="Skip storage blobs whose path starts with PREFIX (can be repeated)")
+args = parser.parse_args()
+
+OUTPUT_DIR = Path(args.output_dir)
+SKIP_STORAGE_PREFIXES: list[str] = args.skip_storage_prefix
+
+# Ensure emulator env vars are set
+if not os.getenv("FIRESTORE_EMULATOR_HOST"):
+    os.environ["FIRESTORE_EMULATOR_HOST"] = "localhost:8080"
+
+storage_host_override = os.getenv("QUARKUS_GOOGLE_CLOUD_STORAGE_HOST_OVERRIDE")
+if storage_host_override:
+    os.environ["STORAGE_EMULATOR_HOST"] = storage_host_override
+elif not os.getenv("STORAGE_EMULATOR_HOST"):
+    os.environ["STORAGE_EMULATOR_HOST"] = "http://localhost:9199"
+
+STORAGE_BUCKET = os.getenv("GCS_BUCKET_NAME", "demo-bdt-dev.appspot.com")
+PROJECT_ID = os.getenv("QUARKUS_GOOGLE_CLOUD_PROJECT_ID", "demo-bdt-dev")
+
+
+# ---------------------------------------------------------------------------
+# Initialize Firebase
+# ---------------------------------------------------------------------------
+
+cred = EmulatorCredentials()
+firebase_admin.initialize_app(cred, {
+    "storageBucket": STORAGE_BUCKET,
+    "projectId": PROJECT_ID,
+})
+
+db: FirestoreClient = firestore.client()
+bucket: Bucket = storage.bucket()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def serialize_value(value: Any) -> Any:
+    """Convert Firestore field values into JSON-serializable types."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return {"_type": "timestamp", "value": value.isoformat()}
+    if isinstance(value, dict):
+        return {k: serialize_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [serialize_value(v) for v in value]
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    # Fallback: convert to string
+    return str(value)
+
+
+def export_document(doc: DocumentSnapshot, base_path: Path) -> None:
+    """Export a single Firestore document and its subcollections."""
+    data = doc.to_dict()
+    if data is None:
+        return
+
+    # Add the document ID into the exported data for reference
+    data["_id"] = doc.id
+
+    serialized = serialize_value(data)
+
+    # Write document JSON
+    doc_file = base_path / f"{doc.id}.json"
+    doc_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(doc_file, "w", encoding="utf-8") as f:
+        json.dump(serialized, f, indent=2, ensure_ascii=False)
+
+    # Recurse into subcollections
+    for subcol_ref in doc.reference.collections():
+        subcol_path = base_path / doc.id / subcol_ref.id
+        docs = subcol_ref.stream()
+        for sub_doc in docs:
+            export_document(sub_doc, subcol_path)
+
+
+def export_firestore(output_dir: Path) -> int:
+    """Export all Firestore collections to JSON files. Returns document count."""
+    firestore_dir = output_dir / "firestore"
+    doc_count = 0
+
+    # Iterate over all root-level collections
+    for collection_ref in db.collections():
+        col_name = collection_ref.id
+        col_path = firestore_dir / col_name
+        print(f"  Exporting collection: {col_name}")
+
+        for doc in collection_ref.stream():
+            export_document(doc, col_path)
+            doc_count += 1
+
+    return doc_count
+
+
+def export_storage(output_dir: Path, skip_prefixes: list[str]) -> int:
+    """Export all Storage blobs to files. Returns file count."""
+    storage_dir = output_dir / "storage"
+    file_count = 0
+
+    blobs = bucket.list_blobs()
+    for blob in blobs:
+        # Skip zero-byte placeholder objects
+        if blob.size == 0:
+            continue
+
+        # Skip blobs matching any of the skip prefixes
+        if any(blob.name.startswith(prefix) for prefix in skip_prefixes):
+            print(f"  Skipping blob: {blob.name} (matched skip prefix)")
+            continue
+
+        dest = storage_dir / blob.name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        print(f"  Exporting blob: {blob.name} ({blob.size} bytes)")
+        blob.download_to_filename(str(dest))
+        file_count += 1
+
+    return file_count
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print(f"Output directory: {OUTPUT_DIR}")
+    print()
+
+    # Clean previous export
+    if OUTPUT_DIR.exists():
+        import shutil
+        shutil.rmtree(OUTPUT_DIR)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Export Firestore
+    print("Exporting Firestore data...")
+    doc_count = export_firestore(OUTPUT_DIR)
+    print(f"  -> {doc_count} document(s) exported")
+    print()
+
+    # Export Storage
+    print("Exporting Storage data...")
+    file_count = export_storage(OUTPUT_DIR, SKIP_STORAGE_PREFIXES)
+    print(f"  -> {file_count} file(s) exported")
+    print()
+
+    # Write a manifest for reference
+    manifest = {
+        "exportedAt": datetime.now(tz=timezone.utc).isoformat() + "Z",
+        "source": "firebase-emulators",
+        "projectId": PROJECT_ID,
+        "storageBucket": STORAGE_BUCKET,
+        "firestoreDocuments": doc_count,
+        "storageFiles": file_count,
+    }
+    manifest_path = OUTPUT_DIR / "manifest.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"Manifest written to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/export-example-screener
+++ b/bin/export-example-screener
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Export Firestore and Storage data from running emulators
+# in a portable JSON format that can be used to seed other environments (including production).
+# Assumes that all the firestore and storage data in the emulators exactly comprises the data needed for the example screener.
+#
+# Usage: bin/export-emulator-data
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+source "$SCRIPT_DIR/functions"
+
+# Load environment from root .env if it exists
+if [ -f "$PROJECT_ROOT/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/.env"
+  set +a
+fi
+
+OUTPUT_DIR="$PROJECT_ROOT/seed-data/example-screener"
+
+echo "=========================================="
+echo "Example Screener Data Export"
+echo "=========================================="
+echo "Output: $OUTPUT_DIR"
+echo ""
+echo "Prerequisites:"
+echo "  - Firebase emulators must be running"
+echo "  - Assumes all data in the emulators pertains to the example screener"
+echo ""
+
+# Helper function to check URL using Python
+check_url() {
+  python3 -c "
+import urllib.request
+import urllib.error
+import sys
+try:
+    urllib.request.urlopen('$1', timeout=5)
+    sys.exit(0)
+except urllib.error.HTTPError:
+    sys.exit(0)
+except Exception as e:
+    print(f'DEBUG: {type(e).__name__}: {e}')
+    sys.exit(1)
+"
+}
+
+# Check if Firebase emulators are running
+MAX_RETRIES=5
+RETRY_DELAY=2
+
+for i in $(seq 1 $MAX_RETRIES); do
+  if check_url "http://localhost:9199"; then
+    break
+  fi
+  if [ $i -eq $MAX_RETRIES ]; then
+    print_error "Firebase Storage emulator not responding at localhost:9199"
+    exit 1
+  fi
+  echo "Waiting for emulators... ($i/$MAX_RETRIES)"
+  sleep $RETRY_DELAY
+done
+
+for i in $(seq 1 $MAX_RETRIES); do
+  if check_url "http://localhost:8080"; then
+    break
+  fi
+  if [ $i -eq $MAX_RETRIES ]; then
+    print_error "Firebase Firestore emulator not responding at localhost:8080"
+    exit 1
+  fi
+  echo "Waiting for emulators... ($i/$MAX_RETRIES)"
+  sleep $RETRY_DELAY
+done
+
+print_success "Firebase emulators are running"
+echo ""
+
+if [[ "$VENV_DIR" != "" ]]; then
+  if [ -f "$VENV_DIR/bin/activate" ]; then
+    source "$VENV_DIR/bin/activate"
+    print_status "Activated virtual environment at $VENV_DIR"
+  fi
+fi
+
+pip install -q -r "$SCRIPT_DIR/library/requirements.txt"
+
+print_status "Exporting emulator data..."
+python3 "$SCRIPT_DIR/export-emulator-data.py" "$OUTPUT_DIR" \
+  --skip-storage-prefix "LibraryApiSchemaExports/"
+
+echo ""
+echo "=========================================="
+print_success "Export complete! Data saved to $OUTPUT_DIR"
+echo "=========================================="

--- a/seed-data/example-screener/firestore/publishedCustomCheck/P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0.json
+++ b/seed-data/example-screener/firestore/publishedCustomCheck/P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0.json
@@ -1,0 +1,37 @@
+{
+  "id": "P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0",
+  "datePublished": 1774637469632,
+  "isArchived": false,
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "parameterDefinitions": [
+    {
+      "type": "string",
+      "key": "p1",
+      "label": "P 1",
+      "required": true
+    }
+  ],
+  "version": "2.0.0",
+  "module": "testchecks",
+  "name": "test",
+  "inputDefinition": {
+    "type": "object",
+    "properties": {
+      "custom": {
+        "type": "object",
+        "properties": {
+          "testinput": {}
+        },
+        "required": [
+          "testinput"
+        ]
+      }
+    },
+    "required": [
+      "custom"
+    ]
+  },
+  "dmnModel": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dmn:definitions xmlns:dmn=\"http://www.omg.org/spec/DMN/20180521/MODEL/\" xmlns=\"https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8\" xmlns:feel=\"http://www.omg.org/spec/DMN/20180521/FEEL/\" xmlns:kie=\"http://www.drools.org/kie/dmn/1.2\" xmlns:dmndi=\"http://www.omg.org/spec/DMN/20180521/DMNDI/\" xmlns:di=\"http://www.omg.org/spec/DMN/20180521/DI/\" xmlns:dc=\"http://www.omg.org/spec/DMN/20180521/DC/\" id=\"_48E2724A-6167-41A4-92B2-FA8BC687355B\" name=\"2793048D-2664-4915-8E51-8F40A6C3D4ED\" typeLanguage=\"http://www.omg.org/spec/DMN/20180521/FEEL/\" namespace=\"https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8\">\n  <dmn:extensionElements/>\n  <dmn:inputData id=\"_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" name=\"testinput\">\n    <dmn:extensionElements/>\n    <dmn:variable id=\"_521661DE-9DA8-4908-8795-2FB78B7BC72C\" name=\"testinput\" typeRef=\"Any\"/>\n  </dmn:inputData>\n  <dmn:decision id=\"_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" name=\"test\">\n    <dmn:extensionElements/>\n    <dmn:variable id=\"_13CF3EFF-653D-4676-A3BD-66655565055D\" name=\"test\" typeRef=\"boolean\"/>\n    <dmn:informationRequirement id=\"_1998B89E-BE3D-468F-841A-4558E131866B\">\n      <dmn:requiredInput href=\"#_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\"/>\n    </dmn:informationRequirement>\n    <dmn:literalExpression id=\"_CBF835CA-7660-4E18-9015-5367A6F0623C\">\n      <dmn:text>true</dmn:text>\n    </dmn:literalExpression>\n  </dmn:decision>\n  <dmndi:DMNDI>\n    <dmndi:DMNDiagram id=\"_839C64D7-3137-4E22-A2F2-3D54CDEE1FF7\" name=\"DRG\">\n      <di:extension>\n        <kie:ComponentsWidthsExtension>\n          <kie:ComponentWidths dmnElementRef=\"_CBF835CA-7660-4E18-9015-5367A6F0623C\">\n            <kie:width>300</kie:width>\n          </kie:ComponentWidths>\n        </kie:ComponentsWidthsExtension>\n      </di:extension>\n      <dmndi:DMNShape id=\"dmnshape-drg-_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" dmnElementRef=\"_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" isCollapsed=\"false\">\n        <dmndi:DMNStyle>\n          <dmndi:FillColor red=\"255\" green=\"255\" blue=\"255\"/>\n          <dmndi:StrokeColor red=\"0\" green=\"0\" blue=\"0\"/>\n          <dmndi:FontColor red=\"0\" green=\"0\" blue=\"0\"/>\n        </dmndi:DMNStyle>\n        <dc:Bounds x=\"411\" y=\"187\" width=\"100\" height=\"50\"/>\n        <dmndi:DMNLabel/>\n      </dmndi:DMNShape>\n      <dmndi:DMNShape id=\"dmnshape-drg-_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" dmnElementRef=\"_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" isCollapsed=\"false\">\n        <dmndi:DMNStyle>\n          <dmndi:FillColor red=\"255\" green=\"255\" blue=\"255\"/>\n          <dmndi:StrokeColor red=\"0\" green=\"0\" blue=\"0\"/>\n          <dmndi:FontColor red=\"0\" green=\"0\" blue=\"0\"/>\n        </dmndi:DMNStyle>\n        <dc:Bounds x=\"419\" y=\"76\" width=\"100\" height=\"50\"/>\n        <dmndi:DMNLabel/>\n      </dmndi:DMNShape>\n      <dmndi:DMNEdge id=\"dmnedge-drg-_1998B89E-BE3D-468F-841A-4558E131866B-AUTO-TARGET\" dmnElementRef=\"_1998B89E-BE3D-468F-841A-4558E131866B\">\n        <di:waypoint x=\"461\" y=\"212\"/>\n        <di:waypoint x=\"469\" y=\"126\"/>\n      </dmndi:DMNEdge>\n    </dmndi:DMNDiagram>\n  </dmndi:DMNDI>\n</dmn:definitions>",
+  "description": "desc",
+  "_id": "P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0"
+}

--- a/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT.json
+++ b/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT.json
@@ -1,0 +1,18 @@
+{
+  "id": "06NGTnKHQBSQP8Z9JEZl",
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "screenerName": "Example - Philly Property Tax Relief",
+  "benefits": [
+    {
+      "id": "34d0cd24-d5c1-4073-9f95-f56454855dc3",
+      "name": "Homestead Exemption",
+      "description": "If you own your primary residence, you are eligible for the Homestead Exemption on your Real Estate Tax. The Homestead Exemption reduces the taxable portion of your property’s assessed value.\n\nWith this exemption, the property’s assessed value is reduced by $100,000. Most homeowners will save about $1,399 a year on their Real Estate Tax bill starting in 2025.\n\nmore info:\nhttps://www.phila.gov/services/payments-assistance-taxes/taxes/property-and-real-estate-taxes/get-real-estate-tax-relief/get-the-homestead-exemption/"
+    },
+    {
+      "id": "4b1aea4c-9ef7-4074-9a6a-c41149dcb437",
+      "name": "OOPA",
+      "description": "desc"
+    }
+  ],
+  "_id": "ummKCKkeHAYt5Kc6DAgT"
+}

--- a/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT/customBenefit/0zq0n4DywnNtDRCGugsF.json
+++ b/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT/customBenefit/0zq0n4DywnNtDRCGugsF.json
@@ -1,0 +1,120 @@
+{
+  "id": "34d0cd24-d5c1-4073-9f95-f56454855dc3",
+  "name": "Homestead Exemption",
+  "description": "If you own your primary residence, you are eligible for the Homestead Exemption on your Real Estate Tax. The Homestead Exemption reduces the taxable portion of your property’s assessed value.\n\nWith this exemption, the property’s assessed value is reduced by $100,000. Most homeowners will save about $1,399 a year on their Real Estate Tax bill starting in 2025.\n\nmore info:\nhttps://www.phila.gov/services/payments-assistance-taxes/taxes/property-and-real-estate-taxes/get-real-estate-tax-relief/get-the-homestead-exemption/",
+  "checks": [
+    {
+      "checkModule": "enrollment",
+      "checkVersion": "0.7.1",
+      "parameters": {
+        "personId": "client",
+        "benefit": "PhlHomesteadExemption"
+      },
+      "checkName": "person-not-enrolled-in-benefit",
+      "evaluationUrl": "/api/v1/checks/enrollment/person-not-enrolled-in-benefit",
+      "parameterDefinitions": [
+        {
+          "type": "string",
+          "key": "personId",
+          "label": "personId",
+          "required": false
+        },
+        {
+          "type": "string",
+          "key": "benefit",
+          "label": "benefit",
+          "required": false
+        }
+      ],
+      "checkId": "2141660a-e38f-4b15-af15-183830d80a29",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "enrollments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "personId": {
+                  "type": "string"
+                },
+                "benefit": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-enrollment-person-not-enrolled-in-benefit-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "owner-occupant",
+      "checkId": "a89fcb2a-63c2-4027-8531-2b2f6fe225da",
+      "evaluationUrl": "/api/v1/checks/residence/owner-occupant",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "ownerOccupant": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-owner-occupant-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "lives-in-philadelphia-pa",
+      "checkId": "9a74334a-0d57-47cf-8f05-df065de1c448",
+      "evaluationUrl": "/api/v1/checks/residence/lives-in-philadelphia-pa",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "livesInPhiladelphiaPa": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-lives-in-philadelphia-pa-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "no-ten-year-tax-abatement",
+      "checkId": "00689e40-b181-40e7-9b0b-a21473fc79c7",
+      "evaluationUrl": "/api/v1/checks/residence/no-ten-year-tax-abatement",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "tenYearTaxAbatement": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-no-ten-year-tax-abatement-0.7.1"
+    }
+  ],
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "_id": "0zq0n4DywnNtDRCGugsF"
+}

--- a/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT/customBenefit/PBxsMT3tiFr7jroCTKqI.json
+++ b/seed-data/example-screener/firestore/publishedScreener/ummKCKkeHAYt5Kc6DAgT/customBenefit/PBxsMT3tiFr7jroCTKqI.json
@@ -1,0 +1,110 @@
+{
+  "id": "4b1aea4c-9ef7-4074-9a6a-c41149dcb437",
+  "name": "OOPA",
+  "description": "desc",
+  "checks": [
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "tax-delinquent",
+      "checkId": "b8e5f87b-5677-4d49-a408-e443b246a396",
+      "evaluationUrl": "/api/v1/checks/residence/tax-delinquent",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "taxDelinquent": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-tax-delinquent-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "lives-in-philadelphia-pa",
+      "checkId": "58a781db-2e3b-45ea-8987-623aca4f73cb",
+      "evaluationUrl": "/api/v1/checks/residence/lives-in-philadelphia-pa",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "livesInPhiladelphiaPa": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-lives-in-philadelphia-pa-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "owner-occupant",
+      "checkId": "ede9c8e7-3b68-4ba5-ae19-4ba4453f4fa2",
+      "evaluationUrl": "/api/v1/checks/residence/owner-occupant",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "ownerOccupant": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-owner-occupant-0.7.1"
+    },
+    {
+      "checkModule": "testchecks",
+      "checkVersion": "2.0.0",
+      "parameters": {
+        "p1": "blah"
+      },
+      "checkName": "test",
+      "checkId": "1251f9f5-bf24-451e-95c8-7c3c59f46502",
+      "parameterDefinitions": [
+        {
+          "type": "string",
+          "key": "p1",
+          "label": "P 1",
+          "required": true
+        }
+      ],
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "custom": {
+            "type": "object",
+            "properties": {
+              "testinput": {}
+            },
+            "required": [
+              "testinput"
+            ]
+          }
+        },
+        "required": [
+          "custom"
+        ]
+      },
+      "sourceCheckId": "P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0"
+    }
+  ],
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "_id": "PBxsMT3tiFr7jroCTKqI"
+}

--- a/seed-data/example-screener/firestore/system/config.json
+++ b/seed-data/example-screener/firestore/system/config.json
@@ -1,0 +1,8 @@
+{
+  "latestJsonStoragePath": "LibraryApiSchemaExports/export_2026-03-27_21-03-54.json",
+  "updatedAt": {
+    "_type": "timestamp",
+    "value": "2026-03-27T21:03:54.944000+00:00"
+  },
+  "_id": "config"
+}

--- a/seed-data/example-screener/firestore/workingCustomCheck/W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test.json
+++ b/seed-data/example-screener/firestore/workingCustomCheck/W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test.json
@@ -1,0 +1,33 @@
+{
+  "id": "W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test",
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "isArchived": false,
+  "parameterDefinitions": [
+    {
+      "type": "string",
+      "key": "p1",
+      "label": "P 1",
+      "required": true
+    }
+  ],
+  "version": "2.0.0",
+  "description": "desc",
+  "module": "testchecks",
+  "inputDefinition": {
+    "type": "object",
+    "properties": {
+      "custom": {
+        "type": "object",
+        "required": [
+          "testinput"
+        ]
+      }
+    },
+    "required": [
+      "custom"
+    ]
+  },
+  "dmnModel": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dmn:definitions xmlns:dmn=\"http://www.omg.org/spec/DMN/20180521/MODEL/\" xmlns=\"https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8\" xmlns:feel=\"http://www.omg.org/spec/DMN/20180521/FEEL/\" xmlns:kie=\"http://www.drools.org/kie/dmn/1.2\" xmlns:dmndi=\"http://www.omg.org/spec/DMN/20180521/DMNDI/\" xmlns:di=\"http://www.omg.org/spec/DMN/20180521/DI/\" xmlns:dc=\"http://www.omg.org/spec/DMN/20180521/DC/\" id=\"_48E2724A-6167-41A4-92B2-FA8BC687355B\" name=\"2793048D-2664-4915-8E51-8F40A6C3D4ED\" typeLanguage=\"http://www.omg.org/spec/DMN/20180521/FEEL/\" namespace=\"https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8\">\n  <dmn:extensionElements/>\n  <dmn:inputData id=\"_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" name=\"testinput\">\n    <dmn:extensionElements/>\n    <dmn:variable id=\"_521661DE-9DA8-4908-8795-2FB78B7BC72C\" name=\"testinput\" typeRef=\"Any\"/>\n  </dmn:inputData>\n  <dmn:decision id=\"_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" name=\"test\">\n    <dmn:extensionElements/>\n    <dmn:variable id=\"_13CF3EFF-653D-4676-A3BD-66655565055D\" name=\"test\" typeRef=\"boolean\"/>\n    <dmn:informationRequirement id=\"_1998B89E-BE3D-468F-841A-4558E131866B\">\n      <dmn:requiredInput href=\"#_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\"/>\n    </dmn:informationRequirement>\n    <dmn:literalExpression id=\"_CBF835CA-7660-4E18-9015-5367A6F0623C\">\n      <dmn:text>true</dmn:text>\n    </dmn:literalExpression>\n  </dmn:decision>\n  <dmndi:DMNDI>\n    <dmndi:DMNDiagram id=\"_839C64D7-3137-4E22-A2F2-3D54CDEE1FF7\" name=\"DRG\">\n      <di:extension>\n        <kie:ComponentsWidthsExtension>\n          <kie:ComponentWidths dmnElementRef=\"_CBF835CA-7660-4E18-9015-5367A6F0623C\">\n            <kie:width>300</kie:width>\n          </kie:ComponentWidths>\n        </kie:ComponentsWidthsExtension>\n      </di:extension>\n      <dmndi:DMNShape id=\"dmnshape-drg-_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" dmnElementRef=\"_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF\" isCollapsed=\"false\">\n        <dmndi:DMNStyle>\n          <dmndi:FillColor red=\"255\" green=\"255\" blue=\"255\"/>\n          <dmndi:StrokeColor red=\"0\" green=\"0\" blue=\"0\"/>\n          <dmndi:FontColor red=\"0\" green=\"0\" blue=\"0\"/>\n        </dmndi:DMNStyle>\n        <dc:Bounds x=\"411\" y=\"187\" width=\"100\" height=\"50\"/>\n        <dmndi:DMNLabel/>\n      </dmndi:DMNShape>\n      <dmndi:DMNShape id=\"dmnshape-drg-_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" dmnElementRef=\"_6A5A2558-0282-4789-957A-ADE53EAD4CC6\" isCollapsed=\"false\">\n        <dmndi:DMNStyle>\n          <dmndi:FillColor red=\"255\" green=\"255\" blue=\"255\"/>\n          <dmndi:StrokeColor red=\"0\" green=\"0\" blue=\"0\"/>\n          <dmndi:FontColor red=\"0\" green=\"0\" blue=\"0\"/>\n        </dmndi:DMNStyle>\n        <dc:Bounds x=\"419\" y=\"76\" width=\"100\" height=\"50\"/>\n        <dmndi:DMNLabel/>\n      </dmndi:DMNShape>\n      <dmndi:DMNEdge id=\"dmnedge-drg-_1998B89E-BE3D-468F-841A-4558E131866B-AUTO-TARGET\" dmnElementRef=\"_1998B89E-BE3D-468F-841A-4558E131866B\">\n        <di:waypoint x=\"461\" y=\"212\"/>\n        <di:waypoint x=\"469\" y=\"126\"/>\n      </dmndi:DMNEdge>\n    </dmndi:DMNDiagram>\n  </dmndi:DMNDI>\n</dmn:definitions>",
+  "name": "test",
+  "_id": "W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test"
+}

--- a/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl.json
+++ b/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl.json
@@ -1,0 +1,20 @@
+{
+  "id": "06NGTnKHQBSQP8Z9JEZl",
+  "screenerName": "Example - Philly Property Tax Relief",
+  "publishedScreenerId": "ummKCKkeHAYt5Kc6DAgT",
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "lastPublishDate": "2026-03-27T19:32:54.559213053Z",
+  "benefits": [
+    {
+      "id": "34d0cd24-d5c1-4073-9f95-f56454855dc3",
+      "name": "Homestead Exemption",
+      "description": "If you own your primary residence, you are eligible for the Homestead Exemption on your Real Estate Tax. The Homestead Exemption reduces the taxable portion of your property’s assessed value.\n\nWith this exemption, the property’s assessed value is reduced by $100,000. Most homeowners will save about $1,399 a year on their Real Estate Tax bill starting in 2025.\n\nmore info:\nhttps://www.phila.gov/services/payments-assistance-taxes/taxes/property-and-real-estate-taxes/get-real-estate-tax-relief/get-the-homestead-exemption/"
+    },
+    {
+      "id": "4b1aea4c-9ef7-4074-9a6a-c41149dcb437",
+      "name": "OOPA",
+      "description": "desc"
+    }
+  ],
+  "_id": "06NGTnKHQBSQP8Z9JEZl"
+}

--- a/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl/customBenefit/34d0cd24-d5c1-4073-9f95-f56454855dc3.json
+++ b/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl/customBenefit/34d0cd24-d5c1-4073-9f95-f56454855dc3.json
@@ -1,0 +1,120 @@
+{
+  "id": "34d0cd24-d5c1-4073-9f95-f56454855dc3",
+  "name": "Homestead Exemption",
+  "description": "If you own your primary residence, you are eligible for the Homestead Exemption on your Real Estate Tax. The Homestead Exemption reduces the taxable portion of your property’s assessed value.\n\nWith this exemption, the property’s assessed value is reduced by $100,000. Most homeowners will save about $1,399 a year on their Real Estate Tax bill starting in 2025.\n\nmore info:\nhttps://www.phila.gov/services/payments-assistance-taxes/taxes/property-and-real-estate-taxes/get-real-estate-tax-relief/get-the-homestead-exemption/",
+  "checks": [
+    {
+      "checkModule": "enrollment",
+      "checkVersion": "0.7.1",
+      "parameters": {
+        "personId": "client",
+        "benefit": "PhlHomesteadExemption"
+      },
+      "checkName": "person-not-enrolled-in-benefit",
+      "evaluationUrl": "/api/v1/checks/enrollment/person-not-enrolled-in-benefit",
+      "parameterDefinitions": [
+        {
+          "type": "string",
+          "key": "personId",
+          "label": "personId",
+          "required": false
+        },
+        {
+          "type": "string",
+          "key": "benefit",
+          "label": "benefit",
+          "required": false
+        }
+      ],
+      "checkId": "2141660a-e38f-4b15-af15-183830d80a29",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "enrollments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "personId": {
+                  "type": "string"
+                },
+                "benefit": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-enrollment-person-not-enrolled-in-benefit-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "owner-occupant",
+      "checkId": "a89fcb2a-63c2-4027-8531-2b2f6fe225da",
+      "evaluationUrl": "/api/v1/checks/residence/owner-occupant",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "ownerOccupant": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-owner-occupant-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "lives-in-philadelphia-pa",
+      "checkId": "9a74334a-0d57-47cf-8f05-df065de1c448",
+      "evaluationUrl": "/api/v1/checks/residence/lives-in-philadelphia-pa",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "livesInPhiladelphiaPa": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-lives-in-philadelphia-pa-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "no-ten-year-tax-abatement",
+      "checkId": "00689e40-b181-40e7-9b0b-a21473fc79c7",
+      "evaluationUrl": "/api/v1/checks/residence/no-ten-year-tax-abatement",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "tenYearTaxAbatement": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-no-ten-year-tax-abatement-0.7.1"
+    }
+  ],
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "_id": "34d0cd24-d5c1-4073-9f95-f56454855dc3"
+}

--- a/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl/customBenefit/4b1aea4c-9ef7-4074-9a6a-c41149dcb437.json
+++ b/seed-data/example-screener/firestore/workingScreener/06NGTnKHQBSQP8Z9JEZl/customBenefit/4b1aea4c-9ef7-4074-9a6a-c41149dcb437.json
@@ -1,0 +1,110 @@
+{
+  "id": "4b1aea4c-9ef7-4074-9a6a-c41149dcb437",
+  "name": "OOPA",
+  "description": "desc",
+  "checks": [
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "tax-delinquent",
+      "checkId": "b8e5f87b-5677-4d49-a408-e443b246a396",
+      "evaluationUrl": "/api/v1/checks/residence/tax-delinquent",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "taxDelinquent": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-tax-delinquent-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "lives-in-philadelphia-pa",
+      "checkId": "58a781db-2e3b-45ea-8987-623aca4f73cb",
+      "evaluationUrl": "/api/v1/checks/residence/lives-in-philadelphia-pa",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "livesInPhiladelphiaPa": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-lives-in-philadelphia-pa-0.7.1"
+    },
+    {
+      "checkModule": "residence",
+      "checkVersion": "0.7.1",
+      "parameters": {},
+      "checkName": "owner-occupant",
+      "checkId": "ede9c8e7-3b68-4ba5-ae19-4ba4453f4fa2",
+      "evaluationUrl": "/api/v1/checks/residence/owner-occupant",
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "simpleChecks": {
+            "type": "object",
+            "properties": {
+              "ownerOccupant": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "sourceCheckId": "L-residence-owner-occupant-0.7.1"
+    },
+    {
+      "checkModule": "testchecks",
+      "checkVersion": "2.0.0",
+      "parameters": {
+        "p1": "blah"
+      },
+      "checkName": "test",
+      "checkId": "1251f9f5-bf24-451e-95c8-7c3c59f46502",
+      "parameterDefinitions": [
+        {
+          "type": "string",
+          "key": "p1",
+          "label": "P 1",
+          "required": true
+        }
+      ],
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "custom": {
+            "type": "object",
+            "properties": {
+              "testinput": {}
+            },
+            "required": [
+              "testinput"
+            ]
+          }
+        },
+        "required": [
+          "custom"
+        ]
+      },
+      "sourceCheckId": "P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0"
+    }
+  ],
+  "ownerId": "4ylHvnZVDmLTU08beOGfZa0ml8nV",
+  "_id": "4b1aea4c-9ef7-4074-9a6a-c41149dcb437"
+}

--- a/seed-data/example-screener/manifest.json
+++ b/seed-data/example-screener/manifest.json
@@ -1,0 +1,8 @@
+{
+  "exportedAt": "2026-03-27T21:34:30.572002+00:00Z",
+  "source": "firebase-emulators",
+  "projectId": "demo-bdt-dev",
+  "storageBucket": "demo-bdt-dev.appspot.com",
+  "firestoreDocuments": 5,
+  "storageFiles": 4
+}

--- a/seed-data/example-screener/storage/check/P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0.dmn
+++ b/seed-data/example-screener/storage/check/P-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test-2.0.0.dmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_48E2724A-6167-41A4-92B2-FA8BC687355B" name="2793048D-2664-4915-8E51-8F40A6C3D4ED" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" name="testinput">
+    <dmn:extensionElements/>
+    <dmn:variable id="_521661DE-9DA8-4908-8795-2FB78B7BC72C" name="testinput" typeRef="Any"/>
+  </dmn:inputData>
+  <dmn:decision id="_6A5A2558-0282-4789-957A-ADE53EAD4CC6" name="test">
+    <dmn:extensionElements/>
+    <dmn:variable id="_13CF3EFF-653D-4676-A3BD-66655565055D" name="test" typeRef="boolean"/>
+    <dmn:informationRequirement id="_1998B89E-BE3D-468F-841A-4558E131866B">
+      <dmn:requiredInput href="#_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_CBF835CA-7660-4E18-9015-5367A6F0623C">
+      <dmn:text>true</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_839C64D7-3137-4E22-A2F2-3D54CDEE1FF7" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_CBF835CA-7660-4E18-9015-5367A6F0623C">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" dmnElementRef="_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="411" y="187" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_6A5A2558-0282-4789-957A-ADE53EAD4CC6" dmnElementRef="_6A5A2558-0282-4789-957A-ADE53EAD4CC6" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="419" y="76" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_1998B89E-BE3D-468F-841A-4558E131866B-AUTO-TARGET" dmnElementRef="_1998B89E-BE3D-468F-841A-4558E131866B">
+        <di:waypoint x="461" y="212"/>
+        <di:waypoint x="469" y="126"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/seed-data/example-screener/storage/check/W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test.dmn
+++ b/seed-data/example-screener/storage/check/W-4ylHvnZVDmLTU08beOGfZa0ml8nV-testchecks-test.dmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_48E2724A-6167-41A4-92B2-FA8BC687355B" name="2793048D-2664-4915-8E51-8F40A6C3D4ED" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_D0E90302-6058-416A-96E3-779658B04AE8">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" name="testinput">
+    <dmn:extensionElements/>
+    <dmn:variable id="_521661DE-9DA8-4908-8795-2FB78B7BC72C" name="testinput" typeRef="Any"/>
+  </dmn:inputData>
+  <dmn:decision id="_6A5A2558-0282-4789-957A-ADE53EAD4CC6" name="test">
+    <dmn:extensionElements/>
+    <dmn:variable id="_13CF3EFF-653D-4676-A3BD-66655565055D" name="test" typeRef="boolean"/>
+    <dmn:informationRequirement id="_1998B89E-BE3D-468F-841A-4558E131866B">
+      <dmn:requiredInput href="#_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_CBF835CA-7660-4E18-9015-5367A6F0623C">
+      <dmn:text>true</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_839C64D7-3137-4E22-A2F2-3D54CDEE1FF7" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_CBF835CA-7660-4E18-9015-5367A6F0623C">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" dmnElementRef="_CAD54B50-6088-4F0C-AED5-E8BEC9F33DEF" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="411" y="187" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_6A5A2558-0282-4789-957A-ADE53EAD4CC6" dmnElementRef="_6A5A2558-0282-4789-957A-ADE53EAD4CC6" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="419" y="76" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_1998B89E-BE3D-468F-841A-4558E131866B-AUTO-TARGET" dmnElementRef="_1998B89E-BE3D-468F-841A-4558E131866B">
+        <di:waypoint x="461" y="212"/>
+        <di:waypoint x="469" y="126"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/seed-data/example-screener/storage/form/published/ummKCKkeHAYt5Kc6DAgT.json
+++ b/seed-data/example-screener/storage/form/published/ummKCKkeHAYt5Kc6DAgT.json
@@ -1,0 +1,1 @@
+{"components":[{"label":"Text field","type":"textfield","_parent":"BDT Form","layout":{"row":"Row_0ig6e1q","columns":null},"id":"Field_1x81oka","key":"Field_1x81oka","_path":["components",0]}],"exporter":{"name":"form-js (https://demo.bpmn.io)","version":"1.15.0"},"id":"BDT Form","schemaVersion":18,"type":"default","_path":[]}

--- a/seed-data/example-screener/storage/form/working/06NGTnKHQBSQP8Z9JEZl.json
+++ b/seed-data/example-screener/storage/form/working/06NGTnKHQBSQP8Z9JEZl.json
@@ -1,0 +1,1 @@
+{"components":[{"label":"Text field","type":"textfield","_parent":"BDT Form","layout":{"row":"Row_0ig6e1q","columns":null},"id":"Field_1x81oka","key":"Field_1x81oka","_path":["components",0]}],"exporter":{"name":"form-js (https://demo.bpmn.io)","version":"1.15.0"},"id":"BDT Form","schemaVersion":18,"type":"default","_path":[]}


### PR DESCRIPTION
(Includes an incorrect/incomplete first version of the example screener)

Proposed full editing workflow (eventually, together with #338):
- start devbox services with a clean slate:
`mv emulator-data emulator-data.bak`
`devbox services up`
- create a new user (which should trigger a copy of the example screener being
  added to the new account - see #338)
- edit the example screener via the web app UI
- run the save script:
`bin/export-example-screener`
- results in the relevant storage and firestore data being saved to
  `seed-data/example-screener/`
