### PR TITLE
Define Alias Name for Checks in Benefits

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/CustomBenefitResource.java
+++ b/builder-api/src/main/java/org/acme/controller/CustomBenefitResource.java
@@ -12,6 +12,7 @@ import org.acme.auth.AuthUtils;
 import org.acme.model.domain.*;
 import org.acme.model.dto.CustomBenefit.AddCheckRequest;
 import org.acme.model.dto.CustomBenefit.CreateCustomBenefitRequest;
+import org.acme.model.dto.CustomBenefit.UpdateCheckAliasRequest;
 import org.acme.model.dto.CustomBenefit.UpdateCheckParametersRequest;
 import org.acme.model.dto.CustomBenefit.UpdateCustomBenefitRequest;
 import org.acme.persistence.EligibilityCheckRepository;
@@ -453,6 +454,71 @@ public class CustomBenefitResource {
             Log.error(e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(Map.of("error", "Could not update check parameters"))
+                    .build();
+        }
+    }
+
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/screener/{screenerId}/benefit/{benefitId}/check/{checkId}/alias")
+    public Response updateCheckAlias(
+        @Context SecurityIdentity identity,
+        @PathParam("screenerId") String screenerId,
+        @PathParam("benefitId") String benefitId,
+        @PathParam("checkId") String checkId,
+        UpdateCheckAliasRequest request
+    ) {
+        String userId = AuthUtils.getUserId(identity);
+
+        if (!isUserAuthorizedForScreener(userId, screenerId)) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        try {
+            // Get the benefit
+            Optional<Benefit> benefitOpt = screenerRepository.getCustomBenefit(screenerId, benefitId);
+            if (benefitOpt.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "Benefit not found"))
+                        .build();
+            }
+
+            Benefit benefit = benefitOpt.get();
+            List<CheckConfig> checks = benefit.getChecks();
+
+            if (checks == null || checks.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "Check not found in benefit"))
+                        .build();
+            }
+
+            // Find and update the check with the matching checkId
+            Boolean checkUpdated = false;
+            List<CheckConfig> checkListAfterUpdate = new ArrayList<>();
+            for (CheckConfig check : checks) {
+                if (check.getCheckId().equals(checkId)) {
+                    check.setAliasName(request.aliasName());
+                    checkUpdated = true;
+                }
+                checkListAfterUpdate.add(check);
+            }
+
+            if (!checkUpdated) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "Check not found in benefit"))
+                        .build();
+            }
+
+            benefit.setChecks(checkListAfterUpdate);
+
+            // Save the updated benefit
+            screenerRepository.updateCustomBenefit(screenerId, benefit);
+
+            return Response.ok().build();
+        } catch (Exception e) {
+            Log.error(e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(Map.of("error", "Could not update check alias"))
                     .build();
         }
     }

--- a/builder-api/src/main/java/org/acme/controller/DecisionResource.java
+++ b/builder-api/src/main/java/org/acme/controller/DecisionResource.java
@@ -154,6 +154,7 @@ public class DecisionResource {
                 String uniqueCheckKey = checkConfig.getCheckId() + checkNum;
                 Map<String, Object> checkResultMap = new HashMap<>();
                 checkResultMap.put("name", checkConfig.getCheckName());
+                checkResultMap.put("aliasName", checkConfig.getAliasName());
                 checkResultMap.put("result", evaluationResult);
                 checkResultMap.put("module", checkConfig.getCheckModule() != null ? checkConfig.getCheckModule() : "");
                 checkResultMap.put("version", checkConfig.getCheckVersion() != null ? checkConfig.getCheckVersion() : "");

--- a/builder-api/src/main/java/org/acme/model/domain/CheckConfig.java
+++ b/builder-api/src/main/java/org/acme/model/domain/CheckConfig.java
@@ -19,6 +19,8 @@ public class CheckConfig {
     private String evaluationUrl;
     private JsonNode inputDefinition;
     private List<ParameterDefinition> parameterDefinitions;
+    // optional alias name for this check instance
+    private String aliasName;
 
     public CheckConfig() {
     }
@@ -115,5 +117,13 @@ public class CheckConfig {
 
     public void setSourceCheckId(String sourceCheckId) {
         this.sourceCheckId = sourceCheckId;
+    }
+
+    public String getAliasName() {
+        return aliasName;
+    }
+
+    public void setAliasName(String aliasName) {
+        this.aliasName = aliasName;
     }
 }

--- a/builder-api/src/main/java/org/acme/model/dto/CustomBenefit/UpdateCheckAliasRequest.java
+++ b/builder-api/src/main/java/org/acme/model/dto/CustomBenefit/UpdateCheckAliasRequest.java
@@ -1,0 +1,3 @@
+package org.acme.model.dto.CustomBenefit;
+
+public record UpdateCheckAliasRequest(String aliasName) {}

--- a/builder-frontend/src/api/benefit.ts
+++ b/builder-frontend/src/api/benefit.ts
@@ -97,3 +97,21 @@ export const updateCheckParameters = async (
     throw error;
   }
 };
+
+export const updateCheckAlias = async (
+  screenerId: string,
+  benefitId: string,
+  checkId: string,
+  aliasName: string | null
+): Promise<void> => {
+  const url = apiUrl + "/screener/" + screenerId + "/benefit/" + benefitId + "/check/" + checkId + "/alias";
+  try {
+    const response = await authPatch(url.toString(), { aliasName });
+    if (!response.ok) {
+      throw new Error(`Update alias failed with status: ${response.status}`);
+    }
+  } catch (error) {
+    console.error("Error updating check alias:", error);
+    throw error;
+  }
+};

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/ConfigureBenefit.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/ConfigureBenefit.tsx
@@ -116,6 +116,14 @@ const ConfigureBenefit = ({
                               newCheckData,
                             );
                           }}
+                          updateCheckConfigAlias={(
+                            aliasName: string | null,
+                          ) => {
+                            actions.updateCheckConfigAlias(
+                              checkConfig.checkId,
+                              aliasName,
+                            );
+                          }}
                         />
                       );
                     }}

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/SelectedEligibilityCheck.tsx
@@ -1,6 +1,7 @@
 import { Accessor, createSignal, For, Show } from "solid-js";
 
 import ConfigureCheckModal from "./modals/ConfigureCheckModal";
+import EditAliasModal from "./modals/EditAliasModal";
 
 import { titleCase } from "@/utils/title_case";
 
@@ -9,18 +10,25 @@ import type {
   ParameterDefinition,
   ParameterValues,
 } from "@/types";
+import { PencilIcon } from "lucide-solid";
 
 const SelectedEligibilityCheck = ({
   checkConfig,
   onRemove,
   updateCheckConfigParams,
+  updateCheckConfigAlias,
 }: {
   checkConfig: Accessor<CheckConfig>;
   updateCheckConfigParams: (newCheckData: ParameterValues) => void;
+  updateCheckConfigAlias: (aliasName: string | null) => void;
   onRemove: () => void | null;
 }) => {
   const [configuringCheckModalOpen, setConfiguringCheckModalOpen] =
     createSignal(false);
+  const [editAliasModalOpen, setEditAliasModalOpen] = createSignal(false);
+
+  const displayName = () =>
+    checkConfig().aliasName || checkConfig().checkName;
 
   const unfilledRequiredParameters = () => {
     return [];
@@ -47,9 +55,25 @@ const SelectedEligibilityCheck = ({
             X
           </div>
         </Show>
-        <div class="text-xl font-bold mb-2">
-          {titleCase(checkConfig().checkName)} - {checkConfig().checkVersion}
+        <div class="text-xl font-bold mb-2 flex items-center gap-2">
+          <span>{titleCase(displayName())}</span>
+          <span class="text-gray-500">- {checkConfig().checkVersion}</span>
+          <div
+            class="text-sm text-gray-500 hover:text-gray-700 hover:rounded-2xl p-2 hover:bg-gray-400"
+            onClick={(e) => {
+              e.stopPropagation();
+              setEditAliasModalOpen(true);
+            }}
+            title="Edit alias"
+          >
+            <PencilIcon size={16}/>
+          </div>
         </div>
+        <Show when={checkConfig().aliasName}>
+          <div class="text-sm text-gray-500 mb-1">
+            Original: {checkConfig().checkName}
+          </div>
+        </Show>
         <div class="pl-2 [&:has(+div)]:mb-2">
           {checkConfig().checkDescription}
         </div>
@@ -94,6 +118,16 @@ const SelectedEligibilityCheck = ({
           updateCheckConfigParams={updateCheckConfigParams}
           closeModal={() => {
             setConfiguringCheckModalOpen(false);
+          }}
+        />
+      )}
+
+      {editAliasModalOpen() && (
+        <EditAliasModal
+          checkConfig={checkConfig}
+          updateCheckConfigAlias={updateCheckConfigAlias}
+          closeModal={() => {
+            setEditAliasModalOpen(false);
           }}
         />
       )}

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/benefitResource.ts
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/benefitResource.ts
@@ -5,7 +5,8 @@ import {
   fetchScreenerBenefit,
   addCheckToBenefit,
   removeCheckFromBenefit,
-  updateCheckParameters
+  updateCheckParameters,
+  updateCheckAlias
 } from "@/api/benefit";
 
 import type { Benefit, ParameterValues } from "@/types";
@@ -18,6 +19,10 @@ interface ScreenerBenefitsResource {
     updateCheckConfigParams: (
       checkId: string,
       parameters: ParameterValues
+    ) => void;
+    updateCheckConfigAlias: (
+      checkId: string,
+      aliasName: string | null
     ) => void;
   };
   actionInProgress: Accessor<boolean>;
@@ -92,12 +97,29 @@ const createScreenerBenefits = (
     setActionInProgress(false);
   };
 
+  const updateCheckConfigAlias = async (
+    checkId: string,
+    aliasName: string | null
+  ) => {
+    if (!benefit) return;
+    setActionInProgress(true);
+
+    try {
+      await updateCheckAlias(screenerId(), benefitId(), checkId, aliasName);
+      await refetch();
+    } catch (e) {
+      console.error("Failed to update check alias", e);
+    }
+    setActionInProgress(false);
+  };
+
   return {
     benefit: () => benefit,
     actions: {
       addCheck,
       removeCheck,
       updateCheckConfigParams,
+      updateCheckConfigAlias,
     },
     actionInProgress,
     initialLoadStatus: {

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/modals/EditAliasModal.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/modals/EditAliasModal.tsx
@@ -1,0 +1,77 @@
+import { Accessor, createSignal } from "solid-js";
+
+import { titleCase } from "@/utils/title_case";
+
+import type { CheckConfig } from "@/types";
+
+const EditAliasModal = ({
+  checkConfig,
+  updateCheckConfigAlias,
+  closeModal,
+}: {
+  checkConfig: Accessor<CheckConfig>;
+  updateCheckConfigAlias: (aliasName: string | null) => void;
+  closeModal: () => void;
+}) => {
+  const [aliasValue, setAliasValue] = createSignal(
+    checkConfig().aliasName ?? ""
+  );
+
+  const confirmAndClose = () => {
+    const trimmedValue = aliasValue().trim();
+    updateCheckConfigAlias(trimmedValue === "" ? null : trimmedValue);
+    closeModal();
+  };
+
+  const clearAlias = () => {
+    setAliasValue("");
+  };
+
+  return (
+    <div class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div class="bg-white px-12 py-8 rounded-xl max-w-140 w-1/2 min-w-80">
+        <div class="text-2xl mb-4">
+          Edit Alias: {titleCase(checkConfig().checkName)}
+        </div>
+
+        <div class="mb-4">
+          <div class="text-sm text-gray-600 mb-2">
+            Set an alias name to display instead of the check's original name.
+            Leave empty to use the original name.
+          </div>
+          <div class="flex gap-2">
+            <input
+              type="text"
+              value={aliasValue()}
+              onInput={(e) => setAliasValue(e.target.value)}
+              placeholder={checkConfig().checkName}
+              class="form-input-custom flex-1"
+            />
+            {aliasValue() && (
+              <button
+                class="btn-default btn-gray !text-sm"
+                onClick={clearAlias}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 space-x-2">
+          <button class="btn-default btn-gray !text-sm" onClick={closeModal}>
+            Cancel
+          </button>
+          <button
+            class="btn-default btn-blue !text-sm"
+            onClick={confirmAndClose}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditAliasModal;

--- a/builder-frontend/src/components/project/preview/Results.tsx
+++ b/builder-frontend/src/components/project/preview/Results.tsx
@@ -102,14 +102,23 @@ export default function Results({
                                   </Switch>
                                 </div>
                                 <div class="flex flex-col">
-                                  <div>
-                                    {check.name}
-                                    <Show when={check.module || check.version}>
-                                      <span class="text-gray-500 ml-1">
-                                        ({[check.module, check.version].filter(Boolean).join(" v")})
+                                  <Show when={check.aliasName} fallback={
+                                    <div>
+                                      {check.name}
+                                      <Show when={check.module || check.version}>
+                                        <span class="text-gray-500 ml-1">
+                                          ({[check.module, check.version].filter(Boolean).join(", v")})
+                                        </span>
+                                      </Show>
+                                    </div>
+                                  }>
+                                    <div>
+                                      {check.aliasName}
+                                      <span class="text-gray-500 text-sm ml-1">
+                                        ({check.name}, {[check.module, check.version].filter(Boolean).join(", v")})
                                       </span>
-                                    </Show>
-                                  </div>
+                                    </div>
+                                  </Show>
                                   <Show when={check.parameters && Object.keys(check.parameters).length > 0}>
                                     <div class="text-gray-500 text-sm">
                                       {formatParameters(check.parameters)}

--- a/builder-frontend/src/components/project/preview/types.ts
+++ b/builder-frontend/src/components/project/preview/types.ts
@@ -13,6 +13,7 @@ interface BenefitResult {
 }
 interface CheckResult {
   name: string;
+  aliasName?: string;
   result: OptionalBoolean;
   module: string;
   version: string;

--- a/builder-frontend/src/components/screener/EligibilityResults.tsx
+++ b/builder-frontend/src/components/screener/EligibilityResults.tsx
@@ -70,7 +70,9 @@ function BenefitResult({ benefitResult }: { benefitResult: BenefitResult }) {
               </div>
               <div class="flex flex-col text-xs">
                 <div>
-                  {check.name}
+                  // {check.name}
+                <Show when={check.aliasName} fallback={<div>{check.name}</div>}></Show>
+                  <div>{check.aliasName}</div>
                   <Show when={check.module || check.version}>
                     <span class="text-gray-500 ml-1">
                       (
@@ -93,26 +95,6 @@ function BenefitResult({ benefitResult }: { benefitResult: BenefitResult }) {
           )}
         </For>
       </div>
-      {/* {benefit.info && (
-        <div class="[&:has(+div)]:mb-4">
-          <h4 class="font-bold mb-1 text-sm">Overview</h4>
-          <p class="text-xs">{benefit.info}</p>
-        </div>
-      )}
-      {benefit.appLink && (
-        <div class="[&:has(+div)]:mb-4">
-          <a href={benefit.appLink} target="_blank">
-            <p
-              class="
-                px-5 py-2 rounded-lg select-none
-                rounded-lg font-bold text-white w-fit text-sm
-                bg-green-600 hover:bg-green-700 transition-colors"
-            >
-              Apply Now
-            </p>
-          </a>
-        </div>
-      )} */}
     </article>
   );
 }

--- a/builder-frontend/src/types.ts
+++ b/builder-frontend/src/types.ts
@@ -28,6 +28,8 @@ export interface CheckConfig {
   parameters: ParameterValues;
   inputDefinition: JSONSchema7;
   parameterDefinitions: ParameterDefinition[];
+  // Optional user-defined alias for display purposes
+  aliasName?: string;
 }
 export interface ParameterValues {
   [key: string]: string | number | boolean | string[];
@@ -102,6 +104,7 @@ export interface BenefitResult {
 }
 export interface CheckResult {
   name: string;
+  aliasName?: string;
   result: OptionalBoolean;
   module: string;
   version: string;


### PR DESCRIPTION
Resolves https://github.com/CodeForPhilly/benefit-decision-toolkit/issues/345

- feat: Added ability to define an "alias" name for a CheckConfig in a Benefit.
- chore: Removed extra information from Check name/definitions on Published Screener View.