### PR TITLE
fix "learn more" and "return to top" links

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,7 +1,5 @@
 <footer class="py-12 flex flex-col items-center gap-3 bg-bdt-green-light">
-  <a class="underline w-fit" href=`${import.meta.env.BASE_URL}/#top`
-    >Return to top</a
-  >
+  <a class="underline w-fit" href="/#top">Return to top</a>
   <p class="text-3xl! font-serif mt-2">Benefit Decision Toolkit</p>
   <p>
     <a class="underline" href="https://codeforphilly.org/" target="_blank"

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -12,7 +12,7 @@ import { Content } from "../assets/text/Hero.md";
     >
       <Content />
     </div>
-    <a href=`${import.meta.env.BASE_URL}/#projects`>
+    <a href="/#projects">
       <div
         class="mt-6 w-fit px-6 py-2 pt-3.5 bg-white border-2 border-bdt-blue rounded-full text-sky-700 font-serif text-xl font-bold"
       >


### PR DESCRIPTION
fix "learn more" and "return to top" links, which were probably broken after the move to new domain for the website.