### PR TITLE
fix get started link (/user/intro)

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     alt: An eligibility form for assistance programs.
   actions:
     - text: Get started
-      link: /intro
+      link: /user/intro
       icon: right-arrow
     - text: Visit our website
       link: https://codeforphilly.github.io/benefit-decision-toolkit/


### PR DESCRIPTION
fix get started link which was broken when user and developer sections were added