### PR TITLE
Allow arbitrary keys for form components

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -52,9 +52,9 @@ jobs:
         uses: "actions/cache@v4"
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('builder-api/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('builder-api/pom.xml', 'library-api/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-${{ hashFiles('builder-api/pom.xml') }}
+            ${{ runner.os }}-maven-
 
       - id: "auth" # Configure Workload Identity Federation and generate an access token
         name: "Authenticate to Google Cloud"
@@ -100,23 +100,12 @@ jobs:
       - name: Run all Devbox services
         run: devbox services up -b
 
-      - name: Show service logs
-        if: always()
-        run: |
-          sleep 5
-          ls -la logs || true
-          tail -n 80 logs/firebase-emulators.log || true
-          tail -n 80 logs/library-api.log || true
-          tail -n 80 logs/sync-library-metadata.log || true
-          tail -n 80 logs/builder-api.log || true
-          tail -n 80 logs/builder-frontend.log || true
-
       - name: Wait for App to be available
         run: |
-          timeout 90 bash -c '
-            until curl --fail --silent --show-error http://127.0.0.1:5173/ > /dev/null; do
+          timeout 300 bash -c '
+            until curl --fail --silent http://127.0.0.1:5173/ > /dev/null; do
               echo "Waiting for frontend..."
-              sleep 1
+              sleep 2
             done
           '
       # - name: Wait for App to be available
@@ -130,6 +119,16 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
         working-directory: e2e
+
+      - name: Show service logs on failure
+        if: failure()
+        run: |
+          ls -la logs || true
+          tail -n 80 logs/firebase-emulators.log || true
+          tail -n 80 logs/library-api.log || true
+          tail -n 80 logs/sync-library-metadata.log || true
+          tail -n 80 logs/builder-api.log || true
+          tail -n 80 logs/builder-frontend.log || true
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
@@ -148,4 +147,5 @@ jobs:
 
       # 4) Cleanup #
       - name: Stop all Devbox services
+        if: always()
         run: devbox services stop

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -10,7 +10,6 @@ import {
   Switch,
   Accessor,
 } from "solid-js";
-import toast from "solid-toast";
 import { useParams } from "@solidjs/router";
 
 import { FormEditor } from "@bpmn-io/form-js-editor";
@@ -117,10 +116,6 @@ function FormEditorView({ formSchema, setFormSchema }) {
     if (!formEditor || formPaths.loading) return;
 
     const currentFormPaths: FormPath[] = formPaths() || [];
-    const validPathSet = new Set(
-      currentFormPaths.map((formPath: FormPath) => formPath.path),
-    );
-
     const pathOptionsService = formEditor.get(
       "pathOptionsService",
     ) as PathOptionsService;
@@ -131,41 +126,6 @@ function FormEditorView({ formSchema, setFormSchema }) {
         type: formPath.type,
       })),
     );
-
-    // Clean up any form fields with keys that are no longer valid options
-    const formFieldRegistry = formEditor.get("formFieldRegistry") as any;
-    const modeling = formEditor.get("modeling") as any;
-
-    if (formFieldRegistry && modeling) {
-      const allFields = formFieldRegistry.getAll();
-      const invalidFields: string[] = [];
-
-      for (const field of allFields) {
-        // If field has a key that's not in valid paths (and not empty), reset it
-        // Skip for expressions, which can have custom-defined keys
-        if (
-          field.key &&
-          !validPathSet.has(field.key) &&
-          field.key !== field.id &&
-          field.type !== "expression"
-        ) {
-          invalidFields.push(field.key);
-          modeling.editFormField(field, "key", field.id);
-        }
-      }
-
-      // Notify user if we reset any fields
-      if (invalidFields.length > 0) {
-        setIsUnsaved(true);
-        const fieldCount = invalidFields.length;
-        const message =
-          fieldCount === 1
-            ? `1 field had an invalid key "${invalidFields[0]}" and was reset.`
-            : `${fieldCount} fields had invalid keys and were reset: ${invalidFields.join(", ")}`;
-        toast(message, { duration: 5000, icon: "⚠️" });
-        handleSave();
-      }
-    }
   });
 
   const handleSave = async () => {

--- a/builder-frontend/src/components/project/FormEditorView.tsx
+++ b/builder-frontend/src/components/project/FormEditorView.tsx
@@ -131,11 +131,20 @@ function FormEditorView({ formSchema, setFormSchema }) {
   const handleSave = async () => {
     const projectId = params.projectId;
     const schema = formSchema();
-    setIsUnsaved(false);
     setIsSaving(true);
-    saveFormSchema(projectId, schema);
     clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => setIsSaving(false), 500);
+
+    try {
+      await saveFormSchema(projectId, schema);
+      setIsUnsaved(false);
+    } catch (error) {
+      // Keep the form marked as unsaved so a failed request is not presented
+      // to the user as a successful save.
+      setIsUnsaved(true);
+      console.error("Failed to save form schema", error);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/bpmn-io-dependencies.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/bpmn-io-dependencies.ts
@@ -138,14 +138,47 @@ function Select(props) {
   const ref = useShowEntryEvent(id);
 
   const [ localValue, setLocalValue ] = useState(value);
+  const [ isOpen, setIsOpen ] = useState(false);
 
-  const handleChangeCallback = ({ target }) => {
-    onChange(target.value);
+  const flatOptions = options.flatMap(option => option.children || [ option ]);
+
+  const handleInput = ({ target }) => {
+    setLocalValue(target.value);
   };
 
-  const handleChange = e => {
-    handleChangeCallback(e);
-    setLocalValue(e.target.value);
+  const commitValue = () => {
+    if (localValue !== value) {
+      onChange(localValue);
+    }
+  };
+
+  const handleBlur = () => {
+    commitValue();
+    setIsOpen(false);
+    onBlur && onBlur();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      commitValue();
+      setIsOpen(false);
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setIsOpen(true);
+    }
+  };
+
+  const handleFocus = () => {
+    setIsOpen(true);
+    onFocus && onFocus();
+  };
+
+  const selectOption = (option) => {
+    setLocalValue(option.value);
+    onChange(option.value);
+    setIsOpen(false);
   };
 
   useEffect(() => {
@@ -157,45 +190,59 @@ function Select(props) {
   }, [ value ]);
 
   return (html`
-    <div class="bio-properties-panel-select">
+    <div class="bio-properties-panel-textfield" style="position: relative;">
       <label for=${ prefixId(id) } class="bio-properties-panel-label">
         ${label}
       </label>
-      <select
-        ref=${ ref }
-        id=${ prefixId(id) }
-        name=${ id }
-        class="bio-properties-panel-input"
-        onInput=${ handleChange }
-        onFocus=${ onFocus }
-        onBlur=${ onBlur }
-        value=${ localValue }
-        disabled=${ disabled }
-      >
-        ${options.map((option, idx) => {
-          if (option.children) {
-            return (html`
-              <optgroup key=${ idx } label=${ option.label }>
-                ${option.children.map((child, idx) => (html`
-                  <option
-                    key=${ idx }
-                    value=${ child.value }
-                    disabled=${ child.disabled }
-                  >
-                    ${child.label}
-                  </option>`
-                ))}
-              </optgroup>`
-            );
-          }
-
-          return (html`
-            <option key=${ idx } value=${ option.value } disabled=${ option.disabled }>
-              ${option.label}
-            </option>`
-          );
-        })}
-      </select>
+      <div style="display: flex;">
+        <input
+          ref=${ ref }
+          id=${ prefixId(id) }
+          name=${ id }
+          class="bio-properties-panel-input"
+          style="flex: 1; min-width: 0;"
+          type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls=${ prefixId(`${id}-options`) }
+          aria-expanded=${ isOpen }
+          onInput=${ handleInput }
+          onKeyDown=${ handleKeyDown }
+          onFocus=${ handleFocus }
+          onBlur=${ handleBlur }
+          value=${ localValue }
+          disabled=${ disabled }
+        />
+        <button
+          type="button"
+          class="bio-properties-panel-input"
+          style="flex: 0 0 32px; margin-left: 4px; padding: 0;"
+          aria-label="Show mapped keys"
+          onMouseDown=${ event => event.preventDefault() }
+          onClick=${ () => setIsOpen(!isOpen) }
+          disabled=${ disabled }
+        >⌄</button>
+      </div>
+      ${isOpen && html`
+        <div
+          id=${ prefixId(`${id}-options`) }
+          role="listbox"
+          style="position: absolute; left: 0; right: 0; z-index: 100; max-height: 220px; overflow-y: auto; background: white; border: 1px solid #ccc; box-shadow: 0 2px 6px rgba(0, 0, 0, .15);"
+        >
+          ${flatOptions.map((option, idx) => html`
+            <button
+              key=${ idx }
+              type="button"
+              role="option"
+              aria-selected=${ option.value === localValue }
+              disabled=${ option.disabled }
+              style="display: block; width: 100%; padding: 6px 8px; border: 0; background: ${option.value === localValue ? '#eee' : 'white'}; text-align: left;"
+              onMouseDown=${ event => event.preventDefault() }
+              onClick=${ () => selectOption(option) }
+            >${option.label}</button>
+          `)}
+        </div>
+      `}
     </div>`
   );
 }
@@ -270,7 +317,6 @@ export default function SelectEntry(props) {
       data-entry-id=${ id }>
       <${Select}
         id=${ id }
-        key=${ element }
         label=${ label }
         value=${ value }
         onChange=${ onChange }

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/customKeyDropdownProvider.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/customKeyDropdownProvider.ts
@@ -75,20 +75,17 @@ function CustomKeyDropdown(props: any) {
     // Get the component type to filter compatible options
     const componentType = field.type || '';
 
-    console.log(componentType);
-
     // Get options from the injected service, passing current key to exclude from disabling
     const options = pathOptionsService?.getOptions(currentKey, componentType) || [];
 
-    // Add empty option
-    return [{ value: field.id, label: '(none)' }, ...options];
+    return options;
   };
 
   return SelectEntry({
     element: field,
     id: id || 'key',
     label: 'Key',
-    description: 'Select the data path for this field',
+    description: 'Enter any key or select a mapped data path',
     getValue,
     setValue,
     getOptions

--- a/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
+++ b/builder-frontend/src/components/project/formJsExtensions/customKeyDropdown/pathOptionsService.ts
@@ -95,8 +95,6 @@ export default class PathOptionsService {
    */
   getOptions(currentFieldKey?: string, componentType?: string): PathOption[] {
     const usedKeys = this.getUsedKeys();
-    console.log(this.pathOptions);
-
     return this.pathOptions
       .filter(option => {
         // If no component type filter, show all options

--- a/e2e/tests/screener.spec.ts
+++ b/e2e/tests/screener.spec.ts
@@ -69,7 +69,9 @@ const createFormWithCheckbox = async (page: Page) => {
     await page
       .locator('[data-title="General"].bio-properties-panel-group-header-title')
       .click();
-    await page.getByLabel("Key").selectOption("simpleChecks.ownerOccupant");
+    const keyCombobox = page.getByRole("combobox", { name: "Key" });
+    await keyCombobox.fill("simpleChecks.ownerOccupant");
+    await keyCombobox.press("Enter");
     await page.getByLabel("Field label").fill("Is owner occupant?");
 
     await page.getByTestId("form-editor-save-button").click();


### PR DESCRIPTION
Sometimes one needs arbitrary keys for front-end only components or
perhaps other creative uses.

This change allows that while preserving the ability to select from
mapped keys and validate them.

In the future we may want to add some sort of feature to ensure that
arbitrary keys are only used when you explicitly want them... or just
make the validation more readily apparent, perhaps by color coding
components that are mapped vs. arbitrary?

closes #369


https://github.com/user-attachments/assets/130d14cc-65e7-46bf-b5cc-a9e0ea90cddd

