### PR TITLE
Hide eligibility check details in published screeners

### DIFF
--- a/builder-frontend/src/components/screener/EligibilityResults.tsx
+++ b/builder-frontend/src/components/screener/EligibilityResults.tsx
@@ -1,24 +1,10 @@
-import { Switch, Match, For, Accessor, Show } from "solid-js";
+import { Switch, Match, For, Accessor } from "solid-js";
 
 import type { ScreenerResult, BenefitResult } from "@/types";
 
 import checkIcon from "@/assets/images/checkIcon.svg";
 import questionIcon from "@/assets/images/questionIcon.svg";
 import xIcon from "@/assets/images/xIcon.svg";
-
-function formatParameters(
-  params: Record<string, unknown>,
-  defaultedParameters: string[] = []
-): string {
-  return Object.entries(params)
-    .map(([key, value]) => {
-      const defaultedLabel = defaultedParameters.includes(key)
-        ? " (defaulted to today's date)"
-        : "";
-      return `${key}=${value}${defaultedLabel}`;
-    })
-    .join(", ");
-}
 
 export default function EligibilityResults({
   screenerResult,
@@ -76,34 +62,7 @@ function BenefitResult({ benefitResult }: { benefitResult: BenefitResult }) {
                   </Match>
                 </Switch>
               </div>
-              <div class="flex flex-col text-xs">
-                <div>
-                  // {check.name}
-                <Show when={check.aliasName} fallback={<div>{check.name}</div>}></Show>
-                  <div>{check.aliasName}</div>
-                  <Show when={check.module || check.version}>
-                    <span class="text-gray-500 ml-1">
-                      (
-                      {[check.module, check.version].filter(Boolean).join(" v")}
-                      )
-                    </span>
-                  </Show>
-                </div>
-                <Show
-                  when={
-                    (check.effectiveParameters &&
-                      Object.keys(check.effectiveParameters).length > 0) ||
-                    (check.parameters && Object.keys(check.parameters).length > 0)
-                  }
-                >
-                  <div class="text-gray-500">
-                    {formatParameters(
-                      check.effectiveParameters ?? check.parameters,
-                      check.defaultedParameters
-                    )}
-                  </div>
-                </Show>
-              </div>
+              <div class="text-xs">{check.aliasName || check.name}</div>
             </div>
           )}
         </For>


### PR DESCRIPTION
## Summary
- show each eligibility check custom name when provided
- fall back to the original check name when no custom name is set
- remove original-name duplication, version/module metadata, and parameters from published screener results
  - (keep this extra debug/dev info on the preview screen)

Published Screener screenshot:
<img width="983" height="478" alt="image" src="https://github.com/user-attachments/assets/ca86e6de-4f81-4712-bac4-23acfaafaac9" />

Preview screen screenshot:
<img width="1246" height="432" alt="image" src="https://github.com/user-attachments/assets/f18f93fd-da8a-4f51-8147-b2d54ccd8361" />
