### PR TITLE
Add a wrapper script that runs every test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ firebase-debug.*.log*
 
 emulator-data/
 
+# Staging directory the Firebase CLI leaves in the repo root when an
+# --export-on-exit run fails part way through (see bin/run-e2e-tests).
+firebase-export-*/
+
 # Runtime data
 pids
 *.pid

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This is a monorepo for building and publishing benefit eligibility screeners. Ke
 
 - Preferred one-time setup: `bin/install-devbox && devbox run setup`
 - Start the development stack: `devbox services up`
+- All tests: `devbox run test` (wrapper: `bin/run-all-tests`; accepts `--fail-fast` and suite names `builder-api`, `library-api`, `e2e`)
 - Backend tests: `(cd builder-api && mvn test)`
 - Library tests: `(cd library-api && mvn test)`; DMN API tests require a running library service, then `(cd library-api/test/bdt && bru run)`
 - Frontend build: `(cd builder-frontend && npm run build)`

--- a/bin/run-all-tests
+++ b/bin/run-all-tests
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+
+# Run every automated test suite in the repository.
+#
+# Suites run in this order:
+#   1. builder-api  - JVM unit/integration tests (mvn test)
+#   2. library-api  - JVM unit/integration tests (mvn test)
+#   3. e2e          - bin/run-e2e-tests, which boots the full dev stack with
+#                     devbox services and then runs the library-api Bruno
+#                     collection followed by the Playwright suite.
+#
+# The JVM suites run first because they need nothing but Maven, while the e2e
+# suite takes exclusive ownership of the local service ports and swaps the root
+# emulator-data directory for the e2e fixtures.
+#
+# By default every selected suite runs even if an earlier one fails, so a single
+# invocation reports the complete picture; use --fail-fast to stop at the first
+# failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+source "$SCRIPT_DIR/functions"
+
+cd "$PROJECT_ROOT"
+
+ALL_SUITES=(builder-api library-api e2e)
+FAIL_FAST=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/run-all-tests [options] [suite ...]
+
+Runs every automated test suite in the repository. Run it directly or as
+`devbox run test`; when invoked outside the Devbox environment it re-enters
+Devbox on its own.
+
+Suites:
+  builder-api   builder-api JVM tests (mvn test)
+  library-api   library-api JVM tests (mvn test)
+  e2e           full dev stack, library-api Bruno collection, Playwright suite
+
+With no suite arguments, all suites run in the order listed above.
+
+Options:
+  --fail-fast   Stop after the first failing suite (default: run them all)
+  --list        Print the available suite names and exit
+  -h, --help    Show this help and exit
+
+Examples:
+  devbox run test
+  devbox run test -- --fail-fast
+  bin/run-all-tests builder-api library-api
+USAGE
+}
+
+is_known_suite() {
+  local candidate="$1"
+  local suite
+
+  for suite in "${ALL_SUITES[@]}"; do
+    if [ "$suite" = "$candidate" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+SELECTED_SUITES=()
+ORIGINAL_ARGS=("$@")
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --fail-fast)
+    FAIL_FAST=1
+    ;;
+  --list)
+    printf '%s\n' "${ALL_SUITES[@]}"
+    exit 0
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  -*)
+    print_error "Unknown option: $1"
+    echo ""
+    usage >&2
+    exit 2
+    ;;
+  *)
+    if ! is_known_suite "$1"; then
+      print_error "Unknown suite: $1"
+      echo ""
+      usage >&2
+      exit 2
+    fi
+    SELECTED_SUITES+=("$1")
+    ;;
+  esac
+  shift
+done
+
+if [ "${#SELECTED_SUITES[@]}" -eq 0 ]; then
+  SELECTED_SUITES=("${ALL_SUITES[@]}")
+fi
+
+suite_selected() {
+  local candidate="$1"
+  local suite
+
+  for suite in "${SELECTED_SUITES[@]}"; do
+    if [ "$suite" = "$candidate" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# The suites need this project's Devbox environment (Maven, Node, Bruno CLI,
+# the Playwright browsers, process-compose). When invoked from outside it,
+# re-enter through Devbox. `devbox run` cannot start at all until the root .env
+# named by `env_from` exists, so create it from the example first.
+if [ "${DEVBOX_SHELL_ENABLED:-}" != "1" ]; then
+  if ! command_exists devbox; then
+    print_error "devbox not found. Install it with bin/install-devbox, then rerun this script."
+    exit 1
+  fi
+
+  bin/ensure-root-env-file
+
+  print_status "Re-entering the Devbox environment to run the tests..."
+  exec devbox run -- bin/run-all-tests "${ORIGINAL_ARGS[@]}"
+fi
+
+for required_command in mvn; do
+  if ! command_exists "$required_command"; then
+    print_error "$required_command is required but was not found on PATH."
+    exit 1
+  fi
+done
+
+# The JVM suites read component .env files directly, and bin/run-e2e-tests needs
+# the root .env for the Devbox service graph. Create any that are missing from
+# the checked-in examples before the first suite runs.
+bin/ensure-root-env-file
+
+for component in builder-frontend builder-api library-api; do
+  if [ ! -f "$component/.env" ]; then
+    if [ ! -f "$component/.env.example" ]; then
+      print_error "$component/.env.example not found"
+      exit 1
+    fi
+    cp "$component/.env.example" "$component/.env"
+    print_success "✓ Created $component/.env from .env.example"
+  fi
+done
+
+run_builder_api_suite() {
+  (
+    cd builder-api
+    mvn test
+  )
+}
+
+run_library_api_suite() {
+  (
+    cd library-api
+    mvn test
+  )
+}
+
+run_e2e_suite() {
+  bin/run-e2e-tests
+}
+
+RESULT_NAMES=()
+RESULT_STATUSES=()
+RESULT_DURATIONS=()
+FAILED_COUNT=0
+SKIPPED_COUNT=0
+
+format_duration() {
+  local total_seconds="$1"
+
+  printf '%dm%02ds' "$((total_seconds / 60))" "$((total_seconds % 60))"
+}
+
+record_result() {
+  RESULT_NAMES+=("$1")
+  RESULT_STATUSES+=("$2")
+  RESULT_DURATIONS+=("$3")
+}
+
+run_suite() {
+  local name="$1"
+  local runner="$2"
+  local started_at
+  local duration
+
+  if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAIL_FAST" -eq 1 ]; then
+    print_warning "Skipping $name because an earlier suite failed (--fail-fast)"
+    record_result "$name" "skipped" ""
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    return 0
+  fi
+
+  echo ""
+  print_status "🧪 Running $name tests..."
+  echo ""
+
+  started_at=$SECONDS
+
+  if "$runner"; then
+    duration="$((SECONDS - started_at))"
+    echo ""
+    print_success "$name tests passed in $(format_duration "$duration")"
+    record_result "$name" "passed" "$duration"
+    return 0
+  fi
+
+  duration="$((SECONDS - started_at))"
+  echo ""
+  print_error "$name tests failed after $(format_duration "$duration")"
+  record_result "$name" "failed" "$duration"
+  FAILED_COUNT=$((FAILED_COUNT + 1))
+  return 0
+}
+
+print_status "Test suites selected: ${SELECTED_SUITES[*]}"
+
+if suite_selected builder-api; then
+  run_suite "builder-api" run_builder_api_suite
+fi
+
+if suite_selected library-api; then
+  run_suite "library-api" run_library_api_suite
+fi
+
+if suite_selected e2e; then
+  run_suite "e2e" run_e2e_suite
+fi
+
+echo ""
+print_status "──────────────────────────────────────────"
+print_status "Test summary"
+print_status "──────────────────────────────────────────"
+
+for index in "${!RESULT_NAMES[@]}"; do
+  name="${RESULT_NAMES[$index]}"
+  status="${RESULT_STATUSES[$index]}"
+  duration="${RESULT_DURATIONS[$index]}"
+
+  case "$status" in
+  passed)
+    print_success "$(printf '%-12s passed  (%s)' "$name" "$(format_duration "$duration")")"
+    ;;
+  failed)
+    print_error "$(printf '%-12s failed  (%s)' "$name" "$(format_duration "$duration")")"
+    ;;
+  *)
+    print_warning "$(printf '%-12s skipped' "$name")"
+    ;;
+  esac
+done
+
+echo ""
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  print_error "$FAILED_COUNT test suite(s) failed."
+  exit 1
+fi
+
+if [ "$SKIPPED_COUNT" -gt 0 ]; then
+  print_warning "$SKIPPED_COUNT test suite(s) were skipped."
+fi
+
+print_success "🎉 All selected test suites passed."

--- a/bin/run-e2e-tests
+++ b/bin/run-e2e-tests
@@ -14,6 +14,7 @@ BACKUP_EXPECTED=0
 TEST_DATA_INSTALLED=0
 SERVICES_MAY_BE_RUNNING=0
 MANAGED_APPLICATION_PORTS=(5173 8080 8081 8083 9099 9199)
+PRE_EXISTING_FIREBASE_EXPORTS=()
 
 cd "$PROJECT_ROOT"
 
@@ -38,6 +39,60 @@ report_recovery_state() {
   fi
 
   echo "Do not rerun the E2E runner until this recovery state is resolved." >&2
+}
+
+# The emulators run with --export-on-exit (see process-compose.yml). On shutdown
+# the Firebase CLI stages that export in a `firebase-export-<millis>XXXXXX`
+# directory created with a *relative* path, so it lands in the emulator process's
+# working directory - this repository root - and is only moved into place once
+# every emulator has exported successfully. When one of them fails (the usual
+# cause is the stack being torn down before the storage emulator is serving), the
+# staging directory is orphaned in the repo root. Record what was already there so
+# cleanup can remove only what this run leaked.
+snapshot_firebase_export_dirs() {
+  local dir
+
+  PRE_EXISTING_FIREBASE_EXPORTS=()
+
+  while IFS= read -r -d '' dir; do
+    PRE_EXISTING_FIREBASE_EXPORTS+=("$dir")
+  done < <(find "$PROJECT_ROOT" -maxdepth 1 -type d -name 'firebase-export-*' -print0)
+}
+
+remove_leaked_firebase_export_dirs() {
+  local dir
+  local existing
+  local known
+  local -a leaked=()
+
+  while IFS= read -r -d '' dir; do
+    known=0
+
+    if [ "${#PRE_EXISTING_FIREBASE_EXPORTS[@]}" -ne 0 ]; then
+      for existing in "${PRE_EXISTING_FIREBASE_EXPORTS[@]}"; do
+        if [ "$dir" = "$existing" ]; then
+          known=1
+          break
+        fi
+      done
+    fi
+
+    if [ "$known" -eq 0 ]; then
+      leaked+=("$dir")
+    fi
+  done < <(find "$PROJECT_ROOT" -maxdepth 1 -type d -name 'firebase-export-*' -print0)
+
+  if [ "${#leaked[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  for dir in "${leaked[@]}"; do
+    echo "Removing incomplete emulator export left behind by this run: $dir" >&2
+    if ! rm -rf -- "$dir"; then
+      echo "Failed to remove $dir." >&2
+      return 1
+    fi
+  done
 }
 
 port_has_listener() {
@@ -260,6 +315,12 @@ cleanup() {
     fi
   fi
 
+  if [ "$safe_to_modify_data" -eq 1 ]; then
+    if ! remove_leaked_firebase_export_dirs; then
+      cleanup_code=1
+    fi
+  fi
+
   if [ "$safe_to_modify_data" -eq 0 ]; then
     report_recovery_state
   fi
@@ -403,6 +464,8 @@ elif [ -e "$PROJECT_ROOT/emulator-data" ] && [ ! -d "$PROJECT_ROOT/emulator-data
   echo "Replace it with a directory or remove it before rerunning." >&2
   exit 1
 fi
+
+snapshot_firebase_export_dirs
 
 ensure_env_file ".env" ".env.example"
 ensure_env_file "builder-frontend/.env" "builder-frontend/.env.example"

--- a/bin/run-e2e-tests
+++ b/bin/run-e2e-tests
@@ -354,6 +354,13 @@ export PLAYWRIGHT_BROWSERS_PATH="$PROJECT_ROOT/.devbox/nix/profile/default"
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 
+# This script runs unattended and is itself wrapped by bin/run-all-tests, so the
+# HTML reporter must never start its report server and block on "Press Ctrl+C to
+# quit" after a failure. e2e/playwright.config.ts sets `open: 'never'`; this
+# enforces it regardless of the config in use. The report is still written to
+# e2e/playwright-report and can be viewed with `npx playwright show-report`.
+export PW_TEST_HTML_REPORT_OPEN=never
+
 found_chromium=0
 for dir in "$PLAYWRIGHT_BROWSERS_PATH"/chromium-*; do
   if [ -d "$dir" ]; then
@@ -522,5 +529,16 @@ wait_for_url "builder frontend" "http://localhost:5173/"
 
 (
   cd e2e
+
+  set +e
   ./node_modules/.bin/playwright test "$@"
+  playwright_status=$?
+  set -e
+
+  if [ "$playwright_status" -ne 0 ]; then
+    echo "Playwright HTML report: $PROJECT_ROOT/e2e/playwright-report" >&2
+    echo "View it with: (cd e2e && ./node_modules/.bin/playwright show-report)" >&2
+  fi
+
+  exit "$playwright_status"
 )

--- a/bin/setup
+++ b/bin/setup
@@ -163,6 +163,8 @@ cd ..
 
 print_status "Finished installing frontend dependencies."
 
+# The backends are packaged without their tests here; bin/run-all-tests runs
+# every suite once at the end of setup.
 print_status "📦 Installing backend dependencies..."
 
 if ! command_exists mvn; then
@@ -172,13 +174,13 @@ fi
 
 print_status "Installing library-api dependencies..."
 cd library-api
-mvn clean package
+mvn clean package -DskipTests
 print_success "library-api dependencies installed"
 cd ..
 
 print_status "Installing builder-api dependencies..."
 cd builder-api
-mvn clean package
+mvn clean package -DskipTests
 print_success "builder-api dependencies installed"
 cd ..
 
@@ -207,10 +209,11 @@ echo ""
 
 if [ "$USING_DEVBOX" -eq 1 ]; then
   print_status "🧪 Verifying the complete local development environment..."
-  bin/run-e2e-tests
+  bin/run-all-tests --fail-fast
   print_success "Complete local development environment verified"
 else
   print_warning "Skipping full-stack verification because it requires Devbox."
+  print_warning "Once the dependencies from devbox.json are installed, run 'bin/run-all-tests' to verify the environment."
 fi
 
 echo ""
@@ -225,7 +228,10 @@ echo "  b. If not using devbox and/or plan to develop against real Firebase serv
 echo "2. Run all main web app services locally in dev mode:"
 echo "  a. With devbox: 'devbox services up'"
 echo "  b. Without devbox: install then run 'process-compose'"
-echo "3. Other things to try:"
+echo "3. Run every test suite:"
+echo "  a. With devbox: 'devbox run test'"
+echo "  b. A single suite: 'devbox run test -- library-api'"
+echo "4. Other things to try:"
 echo "  a. Run 'devbox shell' to load the environment without running services."
 echo "  b. Consider using the direnv integration to load dependencies automatically."
 echo "  c. Consider installing the Devbox and Direnv extensions for VS Code."

--- a/devbox.json
+++ b/devbox.json
@@ -24,7 +24,7 @@
         "bin/setup"
       ],
       "test": [
-        "bin/run-all-tests"
+        "bin/run-all-tests \"$@\""
       ],
       "build-library-api-ci": [
         "cd library-api",

--- a/devbox.json
+++ b/devbox.json
@@ -23,6 +23,9 @@
       "setup": [
         "bin/setup"
       ],
+      "test": [
+        "bin/run-all-tests"
+      ],
       "build-library-api-ci": [
         "cd library-api",
         "quarkus build --no-tests"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* The HTML reporter's default `open: 'on-failure'` starts a report server and
+     blocks on "Press Ctrl+C to quit" whenever a test fails, which hangs any
+     script that wraps this suite (bin/run-e2e-tests, bin/run-all-tests). Keep
+     the report on disk and let developers open it with
+     `npx playwright show-report`, and use the list reporter for terminal
+     output. */
+  reporter: [['list'], ['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */

--- a/library-api/src/main/resources/application.properties
+++ b/library-api/src/main/resources/application.properties
@@ -13,3 +13,5 @@ quarkus.devservices.enabled=false
 quarkus.test.continuous-testing=enabled
 
 kogito.generate.rest.decisions=false
+
+quarkus.http.test-port=0


### PR DESCRIPTION
Closes #417.

## What

Adds `bin/run-all-tests`, a single entry point for every automated test suite in the repository, wired up as `devbox run test`.

Suites run in this order:

1. `builder-api` — JVM tests (`mvn test`)
2. `library-api` — JVM tests (`mvn test`)
3. `e2e` — `bin/run-e2e-tests`, which boots the dev stack, runs the library-api Bruno collection, then the Playwright suite

The JVM suites go first because they need nothing but Maven, while the e2e suite takes exclusive ownership of the local service ports and swaps the root `emulator-data` directory for the e2e fixtures.

By default every selected suite runs even when an earlier one fails, so one invocation reports the complete picture. `--fail-fast` stops at the first failure. Individual suites can be selected by name. The script re-enters the Devbox environment on its own when invoked from outside it.

```
devbox run test
devbox run test -- --fail-fast
bin/run-all-tests builder-api library-api
```

Every run ends with a summary table of per-suite status and duration, and exits non-zero if any suite failed.

## Setup now verifies through the wrapper

`bin/setup` previously verified the local environment with `bin/run-e2e-tests`, covering only the Playwright and Bruno suites. It now runs `bin/run-all-tests --fail-fast`, so the JVM suites are part of the verification gate too — and a failing JVM suite no longer costs you the several-minute e2e run.

Setup's `mvn clean package` steps gained `-DskipTests`. The wrapper owns the test run now, so without that change setup would run both JVM suites twice.

## Testing

`bin/run-all-tests` was run end to end against a clean local stack; all three suites pass. `bin/setup` was also re-run end to end for the follow-up change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)