### PR TITLE
Skip test verification during Codespaces prebuilds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetpackio/devbox:latest
+FROM docker.io/jetpackio/devbox:latest
 
 # Installing your devbox project
 WORKDIR /code
@@ -10,6 +10,6 @@ COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} .env.example .env
 
 
-RUN devbox run -- echo "Installed Packages." && nix-store --gc && nix-store --optimise
+RUN devbox run -- echo "Installed Packages." && nix-store --gc
 
 RUN devbox shellenv --init-hook >> ~/.profile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "./Dockerfile",
     "context": ".."
   },
-  "onCreateCommand": "bin/ensure-root-env-file && devbox run setup",
+  "onCreateCommand": "bin/ensure-root-env-file && devbox run setup -- --skip-tests",
   "postStartCommand": "devbox services up -b && echo 'Frontend will open in browser when ready. Run `devbox services attach` to see the running processes.'",
   "forwardPorts": [
     5173,

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ To install devbox (and Nix) and configure your machine for development:
 bin/install-devbox && devbox run setup
 ```
 
+To install and build the dependencies without running the test suites, use:
+
+```bash
+devbox run setup -- --skip-tests
+```
+
 Then, to startup all the services/apps with the default configuration, run:
 
 ```bash

--- a/bin/setup
+++ b/bin/setup
@@ -7,8 +7,39 @@ set -e # Exit on any error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 USING_DEVBOX=0
+SKIP_TESTS=0
 
 source "$SCRIPT_DIR/functions"
+
+usage() {
+  cat <<'EOF'
+Usage: bin/setup [--skip-tests]
+
+Install and configure the local development environment.
+
+Options:
+  --skip-tests  Skip the test-suite verification after setup.
+  -h, --help    Show this help message.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --skip-tests)
+    SKIP_TESTS=1
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    print_error "Unknown option: $1"
+    usage >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
 
 port_has_listener() {
   local port="$1"
@@ -89,7 +120,7 @@ else
   USING_DEVBOX=1
 fi
 
-if [ "$USING_DEVBOX" -eq 1 ]; then
+if [ "$USING_DEVBOX" -eq 1 ] && [ "$SKIP_TESTS" -eq 0 ]; then
   if ! command_exists python3; then
     print_error "python3 not found. Devbox setup requires Python to check the local service state."
     exit 1
@@ -207,7 +238,10 @@ done
 
 echo ""
 
-if [ "$USING_DEVBOX" -eq 1 ]; then
+if [ "$SKIP_TESTS" -eq 1 ]; then
+  print_warning "Skipping test-suite verification (--skip-tests)."
+  print_warning "Run 'devbox run test' when you are ready to verify the environment."
+elif [ "$USING_DEVBOX" -eq 1 ]; then
   print_status "🧪 Verifying the complete local development environment..."
   bin/run-all-tests --fail-fast
   print_success "Complete local development environment verified"

--- a/devbox.json
+++ b/devbox.json
@@ -21,7 +21,7 @@
     ],
     "scripts": {
       "setup": [
-        "bin/setup"
+        "bin/setup \"$@\""
       ],
       "test": [
         "bin/run-all-tests \"$@\""


### PR DESCRIPTION
## Summary

- add a documented `--skip-tests` option to `bin/setup`
- bypass test-only port checks and the final suite verification when selected
- forward arguments through the Devbox setup script
- use the option from the devcontainer `onCreateCommand`

## Why

Codespaces prebuilds consistently fail when Playwright runs from `onCreateCommand`, although the dedicated E2E workflow passes on the same commits. Prebuild setup should install and build dependencies while leaving verification to the dedicated CI workflows.

## Verification

- `bash -n bin/setup`
- JSON validation for `.devcontainer/devcontainer.json` and `devbox.json`
- `devbox run -q setup -- --help`
- `devbox run -q setup -- --skip-tests`
- `git diff --check`
- full local E2E suite before the change: 8 passed