### PR TITLE
Fix first published custom eligibility check version

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -19,9 +19,11 @@ import org.acme.persistence.EligibilityCheckRepository;
 import org.acme.persistence.StorageService;
 import org.acme.service.DmnService;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Path("/api/custom-checks")
@@ -279,9 +281,17 @@ public class EligibilityCheckResource {
                     .build();
         }
 
-        // New checks start at 1.0.0, so only increment after a version has already been published.
-        List<EligibilityCheck> publishedChecks = eligibilityCheckRepository.getPublishedCheckVersions(check);
-        check.setVersion(versionForPublish(check.getVersion(), !publishedChecks.isEmpty()));
+        // A check is created at 1.0.0, so the first publish keeps that version.
+        List<EligibilityCheck> publishedChecks;
+        try {
+            publishedChecks = eligibilityCheckRepository.getPublishedCheckVersions(check);
+        } catch (Exception e){
+            Log.error("Could not read published versions of check " + check.getId(), e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(Map.of("error", "could not read published versions of Check, published check version was not created"))
+                    .build();
+        }
+        check.setVersion(versionForPublish(check.getVersion(), publishedChecks));
 
         // Update the working check so the extracted input definition and current version are saved.
         try {
@@ -381,16 +391,25 @@ public class EligibilityCheckResource {
 
     // ========== Private Helper Methods ==========
 
-    String versionForPublish(String currentVersion, boolean hasPublishedVersions) {
-        return hasPublishedVersions ? incrementMajorVersion(currentVersion) : currentVersion;
+    private static final Comparator<int[]> VERSION_ORDER = Comparator
+            .<int[]>comparingInt(v -> v[0])
+            .thenComparingInt(v -> v[1])
+            .thenComparingInt(v -> v[2]);
+
+    /* The first publish keeps the working version; later ones increment past the highest published version,
+       so a working version that lags what is already published cannot produce a duplicate published id. */
+    String versionForPublish(String workingVersion, List<EligibilityCheck> publishedChecks) {
+        return publishedChecks.stream()
+                .map(EligibilityCheck::getVersion)
+                .filter(Objects::nonNull)
+                .map(this::normalize)
+                .max(VERSION_ORDER)
+                .map(this::incrementMajorVersion)
+                .orElse(workingVersion);
     }
 
-    private String incrementMajorVersion(String version) {
-        int[] v = normalize(version);
-        v[0]++;         // increment major
-        v[1] = 0;       // reset minor
-        v[2] = 0;       // reset patch
-        return v[0] + "." + v[1] + "." + v[2];
+    private String incrementMajorVersion(int[] version) {
+        return (version[0] + 1) + ".0.0";    // increment major, reset minor and patch
     }
 
     private int[] normalize(String version) {

--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -279,8 +279,11 @@ public class EligibilityCheckResource {
                     .build();
         }
 
-        // Update workingCheck so that the incremented version number is saved
-        check.setVersion(incrementMajorVersion(check.getVersion()));
+        // New checks start at 1.0.0, so only increment after a version has already been published.
+        List<EligibilityCheck> publishedChecks = eligibilityCheckRepository.getPublishedCheckVersions(check);
+        check.setVersion(versionForPublish(check.getVersion(), !publishedChecks.isEmpty()));
+
+        // Update the working check so the extracted input definition and current version are saved.
         try {
             eligibilityCheckRepository.updateWorkingCustomCheck(check);
         } catch (Exception e){
@@ -377,6 +380,10 @@ public class EligibilityCheckResource {
     }
 
     // ========== Private Helper Methods ==========
+
+    String versionForPublish(String currentVersion, boolean hasPublishedVersions) {
+        return hasPublishedVersions ? incrementMajorVersion(currentVersion) : currentVersion;
+    }
 
     private String incrementMajorVersion(String version) {
         int[] v = normalize(version);

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -10,7 +10,7 @@ public interface EligibilityCheckRepository {
 
     List<EligibilityCheck> getWorkingCustomChecks(String userId);
 
-    List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck);
+    List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck) throws Exception;
 
     List<EligibilityCheck> getLatestVersionPublishedCustomChecks(String userId);
 

--- a/builder-api/src/main/java/org/acme/persistence/FirestoreUtils.java
+++ b/builder-api/src/main/java/org/acme/persistence/FirestoreUtils.java
@@ -56,30 +56,25 @@ public class FirestoreUtils {
         }
     }
 
-    public static List<Map<String, Object>> getFirestoreDocsByFields(String collection, Map<String, String> fieldValues) {
+    /* Read failures are propagated so callers can tell an empty result apart from an unavailable read. */
+    public static List<Map<String, Object>> getFirestoreDocsByFields(String collection, Map<String, String> fieldValues) throws Exception {
         System.out.println("Fetching documents from collection: " + collection + " with field values: " + fieldValues);
-        System.out.println("Using Firestore instance: " + db.listCollections());
-        try {
-            Query query = db.collection(collection);
-            for (Map.Entry<String, String> entry : fieldValues.entrySet()) {
-                // Add a whereEqualTo clause for each field-value pair
-                query = query.whereEqualTo(entry.getKey(), entry.getValue());
-            }
-            ApiFuture<QuerySnapshot> querySnapshot = query.get();
-            List<QueryDocumentSnapshot> documents;
-            documents = querySnapshot.get().getDocuments();
-
-            return documents.stream()
-                    .map(doc -> {
-                        Map<String, Object> data = doc.getData();
-                        data.put("id", doc.getId());
-                        return data;
-                    })
-                    .toList();
-        }catch(Exception e){
-            Log.error("Error fetching documents from firestore: ", e);
-            return new ArrayList<>();
+        Query query = db.collection(collection);
+        for (Map.Entry<String, String> entry : fieldValues.entrySet()) {
+            // Add a whereEqualTo clause for each field-value pair
+            query = query.whereEqualTo(entry.getKey(), entry.getValue());
         }
+        ApiFuture<QuerySnapshot> querySnapshot = query.get();
+        List<QueryDocumentSnapshot> documents;
+        documents = querySnapshot.get().getDocuments();
+
+        return documents.stream()
+                .map(doc -> {
+                    Map<String, Object> data = doc.getData();
+                    data.put("id", doc.getId());
+                    return data;
+                })
+                .toList();
     }
 
     public static List<Map<String, Object>> getFirestoreDocsByField(String collection, String field, boolean value) {

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -82,7 +82,7 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
         return nums;
     }
 
-    public List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck){
+    public List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck) throws Exception {
         Map<String, String> fieldValues = Map.of(
             "ownerId", workingCustomCheck.getOwnerId(),
             "module", workingCustomCheck.getModule(),

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -1,20 +1,120 @@
 package org.acme.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.ws.rs.core.Response;
+import org.acme.model.domain.EligibilityCheck;
+import org.acme.persistence.EligibilityCheckRepository;
+import org.acme.persistence.StorageService;
+import org.acme.service.DmnService;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class EligibilityCheckResourceTest {
 
-    private final EligibilityCheckResource resource = new EligibilityCheckResource();
+    private static final String USER_ID = "owner-1";
+    private static final String CHECK_ID = "check-1";
 
-    @Test
-    void firstPublishKeepsInitialVersion() {
-        assertEquals("1.0.0", resource.versionForPublish("1.0.0", false));
+    private final EligibilityCheckResource resource = new EligibilityCheckResource();
+    private final EligibilityCheckRepository repository = mock(EligibilityCheckRepository.class);
+    private final StorageService storageService = mock(StorageService.class);
+    private final DmnService dmnService = mock(DmnService.class);
+    private final SecurityIdentity identity = mock(SecurityIdentity.class);
+
+    private EligibilityCheck workingCheck;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resource.eligibilityCheckRepository = repository;
+        resource.storageService = storageService;
+        resource.dmnService = dmnService;
+
+        JsonWebToken principal = mock(JsonWebToken.class);
+        when(principal.<String>getClaim("user_id")).thenReturn(USER_ID);
+        when(identity.getPrincipal()).thenReturn(principal);
+
+        workingCheck = new EligibilityCheck("my-check", "my-module", "a check", List.of(), USER_ID);
+        workingCheck.setId(CHECK_ID);
+
+        when(repository.getWorkingCustomCheck(USER_ID, CHECK_ID)).thenReturn(Optional.of(workingCheck));
+        when(storageService.getCheckDmnModelPath(anyString())).thenReturn("checks/dmn.xml");
+        when(storageService.getStringFromStorage("checks/dmn.xml")).thenReturn(Optional.of("<definitions/>"));
+        when(dmnService.extractInputSchema(anyString(), any(), anyString()))
+                .thenReturn(new ObjectMapper().createObjectNode());
+        when(repository.saveNewPublishedCustomCheck(any())).thenReturn("published-check-1");
     }
 
     @Test
-    void laterPublishIncrementsMajorVersion() {
-        assertEquals("2.0.0", resource.versionForPublish("1.0.0", true));
+    void firstPublishKeepsInitialVersion() throws Exception {
+        when(repository.getPublishedCheckVersions(workingCheck)).thenReturn(List.of());
+
+        Response response = resource.publishCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals("1.0.0", capturedPublishedVersion());
+    }
+
+    @Test
+    void laterPublishIncrementsPastHighestPublishedVersion() throws Exception {
+        workingCheck.setVersion("2.0.0");
+        when(repository.getPublishedCheckVersions(workingCheck))
+                .thenReturn(List.of(publishedVersion("1.0.0"), publishedVersion("2.0.0")));
+
+        Response response = resource.publishCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals("3.0.0", capturedPublishedVersion());
+    }
+
+    // A working version that lags what is already published must not reuse a published version number
+    @Test
+    void staleWorkingVersionDoesNotReusePublishedVersion() throws Exception {
+        workingCheck.setVersion("1.0.0");
+        when(repository.getPublishedCheckVersions(workingCheck))
+                .thenReturn(List.of(publishedVersion("2.0.0"), publishedVersion("1.0.0")));
+
+        Response response = resource.publishCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals("3.0.0", capturedPublishedVersion());
+    }
+
+    // An unreadable version list must not be mistaken for "never published"
+    @Test
+    void publishFailsWhenPublishedVersionsCannotBeRead() throws Exception {
+        workingCheck.setVersion("2.0.0");
+        when(repository.getPublishedCheckVersions(workingCheck)).thenThrow(new RuntimeException("firestore unavailable"));
+
+        Response response = resource.publishCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        verify(repository, never()).saveNewPublishedCustomCheck(any());
+        verify(repository, never()).updateWorkingCustomCheck(any());
+    }
+
+    private EligibilityCheck publishedVersion(String version) {
+        EligibilityCheck published = new EligibilityCheck("my-check", "my-module", "a check", List.of(), USER_ID);
+        published.setVersion(version);
+        return published;
+    }
+
+    /* The version the endpoint actually published */
+    private String capturedPublishedVersion() throws Exception {
+        ArgumentCaptor<EligibilityCheck> captor = ArgumentCaptor.forClass(EligibilityCheck.class);
+        verify(repository).saveNewPublishedCustomCheck(captor.capture());
+        return captor.getValue().getVersion();
     }
 }

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -1,0 +1,20 @@
+package org.acme.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EligibilityCheckResourceTest {
+
+    private final EligibilityCheckResource resource = new EligibilityCheckResource();
+
+    @Test
+    void firstPublishKeepsInitialVersion() {
+        assertEquals("1.0.0", resource.versionForPublish("1.0.0", false));
+    }
+
+    @Test
+    void laterPublishIncrementsMajorVersion() {
+        assertEquals("2.0.0", resource.versionForPublish("1.0.0", true));
+    }
+}


### PR DESCRIPTION
Closes #321

## Summary
- keep a custom eligibility check at `1.0.0` for its first publication
- increment the major version only when a published version already exists
- add regression tests for first and subsequent publications

## Testing
- `devbox run -q -- mvn -f builder-api/pom.xml test` (42 tests passed)