### PR TITLE
fix: create root env before devbox setup

### DIFF
--- a/bin/run-all-tests
+++ b/bin/run-all-tests
@@ -125,8 +125,8 @@ suite_selected() {
 
 # The suites need this project's Devbox environment (Maven, Node, Bruno CLI,
 # the Playwright browsers, process-compose). When invoked from outside it,
-# re-enter through Devbox. `devbox run` cannot start at all until the root .env
-# named by `env_from` exists, so create it from the example first.
+# re-enter through Devbox. Create the root .env first so local overrides are
+# available as soon as Devbox initializes.
 if [ "${DEVBOX_SHELL_ENABLED:-}" != "1" ]; then
   if ! command_exists devbox; then
     print_error "devbox not found. Install it with bin/install-devbox, then rerun this script."

--- a/devbox.json
+++ b/devbox.json
@@ -13,9 +13,10 @@
     "python314Packages.pip@latest",
     "github:NixOS/nixpkgs/fef9403a3e4d31b0a23f0bacebbec52c248fbb51#playwright-driver.browsers"
   ],
-  "env_from": ".env",
   "shell": {
     "init_hook": [
+      "[ -f .env ] || bin/ensure-root-env-file",
+      "set -a; . ./.env; set +a",
       "[ -f .devboxrc ] && . ./.devboxrc",
       "echo 'Welcome to devbox!'"
     ],


### PR DESCRIPTION
## Summary

- create the root `.env` from `.env.example` during Devbox initialization when it is missing
- export root environment variables before Devbox scripts and services run
- remove the `env_from` dependency that prevented `devbox run setup` from starting on a fresh checkout
- update the test runner comment to reflect the new initialization flow

## Testing

- `devbox run -q -- bash -c 'test -f .env && test "$QUARKUS_GOOGLE_CLOUD_PROJECT_ID" = demo-bdt-dev'`
- `devbox run -q setup -- --help`
- `jq empty devbox.json`
- `bash -n bin/ensure-root-env-file bin/run-all-tests bin/setup`
- `git diff --check`
