### PR TITLE
Handle duplicate check names without opaque errors

### DIFF
--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Load frontend ENV file from example
+        run: cp builder-frontend/.env.example builder-frontend/.env
+
       - name: Setup devbox
         uses: ./.github/actions/devbox-setup
 

--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -15,6 +15,7 @@ import org.acme.model.domain.EligibilityCheck;
 import org.acme.model.dto.EligibilityCheck.CheckDmnRequest;
 import org.acme.model.dto.EligibilityCheck.CreateCheckRequest;
 import org.acme.model.dto.EligibilityCheck.EditCheckRequest;
+import org.acme.persistence.DocumentAlreadyExistsException;
 import org.acme.persistence.EligibilityCheckRepository;
 import org.acme.persistence.StorageService;
 import org.acme.service.CustomCheckDmnTemplate;
@@ -83,11 +84,20 @@ public class EligibilityCheckResource {
             request.parameterDefinitions(),
             userId
         );
+        String checkId = eligibilityCheckRepository.getWorkingId(newCheck);
+        Optional<EligibilityCheck> existingCheck = eligibilityCheckRepository
+                .getWorkingCustomCheck(userId, checkId, true);
+        if (existingCheck.isPresent()) {
+            return duplicateCheckResponse(request, existingCheck.get().getIsArchived());
+        }
+
         String initialDmnModel = customCheckDmnTemplate.create(request.name(), request.description());
 
-        String checkId;
         try {
             checkId = eligibilityCheckRepository.saveNewWorkingCustomCheck(newCheck);
+        } catch (DocumentAlreadyExistsException e) {
+            Log.info("Check " + checkId + " was created concurrently");
+            return duplicateCheckResponse(request, false);
         } catch (Exception e){
             Log.error("Could not save new check for user " + userId, e);
             return  Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -119,6 +129,18 @@ public class EligibilityCheckResource {
 
         newCheck.setDmnModel(initialDmnModel);
         return Response.ok(newCheck, MediaType.APPLICATION_JSON).build();
+    }
+
+    private Response duplicateCheckResponse(CreateCheckRequest request, boolean archived) {
+        String message = archived
+                ? "A check named \"" + request.name() + "\" in module \"" + request.module()
+                    + "\" is archived. Restore it or choose a different name."
+                : "You already have a check named \"" + request.name() + "\" in module \""
+                    + request.module() + "\".";
+        return Response.status(Response.Status.CONFLICT)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Map.of("error", message))
+                .build();
     }
 
     // ========== Single Resource Endpoints ==========

--- a/builder-api/src/main/java/org/acme/persistence/DocumentAlreadyExistsException.java
+++ b/builder-api/src/main/java/org/acme/persistence/DocumentAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package org.acme.persistence;
+
+public class DocumentAlreadyExistsException extends Exception {
+
+    public DocumentAlreadyExistsException(String documentId, Throwable cause) {
+        super("Document already exists: " + documentId, cause);
+    }
+}

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -22,6 +22,8 @@ public interface EligibilityCheckRepository {
 
     Optional<EligibilityCheck> getPublishedCustomCheck(String userId, String checkId);
 
+    String getWorkingId(EligibilityCheck check);
+
     String saveNewWorkingCustomCheck(EligibilityCheck check) throws Exception;
 
     String saveNewPublishedCustomCheck(EligibilityCheck check) throws Exception;

--- a/builder-api/src/main/java/org/acme/persistence/FirestoreUtils.java
+++ b/builder-api/src/main/java/org/acme/persistence/FirestoreUtils.java
@@ -1,6 +1,8 @@
 package org.acme.persistence;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
 import io.quarkus.logging.Log;
@@ -187,6 +189,10 @@ public class FirestoreUtils {
             throw new Exception("Thread interrupted while saving to Firestore", e);
         } catch (ExecutionException e) {
             Log.error(e);
+            if (e.getCause() instanceof ApiException apiException
+                    && apiException.getStatusCode().getCode() == StatusCode.Code.ALREADY_EXISTS) {
+                throw new DocumentAlreadyExistsException(documentId, e);
+            }
             throw new Exception("Failed to write document to Firestore", e);
         }
     }

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -188,6 +188,7 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
         FirestoreUtils.updateDocument(CollectionNames.PUBLISHED_CUSTOM_CHECK_COLLECTION, data, check.getId());
     }
 
+    @Override
     public String getWorkingId(EligibilityCheck check) {
         return CheckStatus.WORKING.getCode() + "-" + check.getOwnerId() + "-" + check.getModule() + "-" + check.getName();
     }

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.Response;
 import org.acme.model.domain.EligibilityCheck;
 import org.acme.model.dto.EligibilityCheck.CreateCheckRequest;
 import org.acme.persistence.EligibilityCheckRepository;
+import org.acme.persistence.DocumentAlreadyExistsException;
 import org.acme.persistence.StorageService;
 import org.acme.service.CustomCheckDmnTemplate;
 import org.acme.service.DmnService;
@@ -61,6 +62,10 @@ class EligibilityCheckResourceTest {
         when(dmnService.extractInputSchema(anyString(), any(), anyString()))
                 .thenReturn(new ObjectMapper().createObjectNode());
         when(repository.saveNewPublishedCustomCheck(any())).thenReturn("published-check-1");
+        when(repository.getWorkingId(any())).thenAnswer(invocation -> {
+            EligibilityCheck check = invocation.getArgument(0);
+            return "W-" + check.getOwnerId() + "-" + check.getModule() + "-" + check.getName();
+        });
     }
 
     @Test
@@ -116,6 +121,66 @@ class EligibilityCheckResourceTest {
 
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
         verify(repository).deleteWorkingCustomCheck(checkId);
+    }
+
+    @Test
+    void createCustomCheckRejectsAnExistingActiveCheck() throws Exception {
+        CreateCheckRequest request = createCheckRequest();
+        String checkId = "W-owner-1-income-incomeCheck";
+        EligibilityCheck existing = new EligibilityCheck(
+                request.name(), request.module(), request.description(), List.of(), USER_ID);
+        when(repository.getWorkingCustomCheck(USER_ID, checkId, true)).thenReturn(Optional.of(existing));
+
+        Response response = resource.createCustomCheck(identity, request);
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        assertEquals(
+                "You already have a check named \"incomeCheck\" in module \"income\".",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(repository, never()).saveNewWorkingCustomCheck(any());
+        verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void createCustomCheckExplainsAnArchivedCollision() throws Exception {
+        CreateCheckRequest request = createCheckRequest();
+        String checkId = "W-owner-1-income-incomeCheck";
+        EligibilityCheck existing = new EligibilityCheck(
+                request.name(), request.module(), request.description(), List.of(), USER_ID);
+        existing.setIsArchived(true);
+        when(repository.getWorkingCustomCheck(USER_ID, checkId, true)).thenReturn(Optional.of(existing));
+
+        Response response = resource.createCustomCheck(identity, request);
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        assertEquals(
+                "A check named \"incomeCheck\" in module \"income\" is archived. Restore it or choose a different name.",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(repository, never()).saveNewWorkingCustomCheck(any());
+    }
+
+    @Test
+    void createCustomCheckMapsAConcurrentCollisionToConflict() throws Exception {
+        CreateCheckRequest request = createCheckRequest();
+        String checkId = "W-owner-1-income-incomeCheck";
+        when(repository.saveNewWorkingCustomCheck(any()))
+                .thenThrow(new DocumentAlreadyExistsException(checkId, new RuntimeException()));
+
+        Response response = resource.createCustomCheck(identity, request);
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        assertEquals(
+                "You already have a check named \"incomeCheck\" in module \"income\".",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
+    }
+
+    private CreateCheckRequest createCheckRequest() {
+        return new CreateCheckRequest(
+                "incomeCheck",
+                "income",
+                "Checks the applicant's income",
+                List.of());
     }
 
     @Test

--- a/builder-frontend/src/api/check.test.ts
+++ b/builder-frontend/src/api/check.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/auth", () => ({
+  authGet: vi.fn(),
+  authPatch: vi.fn(),
+  authPost: vi.fn(),
+  authPut: vi.fn(),
+}));
+
+import { authPost } from "@/api/auth";
+import { addCheck, ApiError } from "./check";
+
+const request = {
+  name: "incomeCheck",
+  module: "income",
+  description: "Checks income",
+  parameterDefinitions: [],
+};
+
+describe("addCheck", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reports the API error message when check creation fails", async () => {
+    vi.mocked(authPost).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error:
+            'You already have a check named "incomeCheck" in module "income".',
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(addCheck(request)).rejects.toThrow(
+      'You already have a check named "incomeCheck" in module "income".',
+    );
+  });
+
+  it("carries the response status so callers can tell failures apart", async () => {
+    vi.mocked(authPost).mockResolvedValue(
+      new Response(JSON.stringify({ error: "Could not save Check" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(addCheck(request)).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+
+  it("falls back to the status when the error response is not JSON", async () => {
+    vi.mocked(authPost).mockResolvedValue(
+      new Response("unavailable", { status: 503 }),
+    );
+
+    await expect(addCheck(request)).rejects.toThrow(
+      "Post failed with status: 503",
+    );
+  });
+
+  it("rejects with an ApiError", async () => {
+    vi.mocked(authPost).mockResolvedValue(
+      new Response("unavailable", { status: 503 }),
+    );
+
+    await expect(addCheck(request)).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/builder-frontend/src/api/check.ts
+++ b/builder-frontend/src/api/check.ts
@@ -10,6 +10,17 @@ import type {
 
 const apiUrl = env.apiUrl;
 
+/* Carries the response status so callers can tell a rejected request apart from a failed one. */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 export const fetchPublicChecks = async (): Promise<EligibilityCheck[]> => {
   const url = apiUrl + "/library-checks";
   try {
@@ -63,7 +74,14 @@ export const addCheck = async (
     });
 
     if (!response.ok) {
-      throw new Error(`Post failed with status: ${response.status}`);
+      let message = `Post failed with status: ${response.status}`;
+      try {
+        const body = await response.json();
+        if (typeof body.error === "string") message = body.error;
+      } catch {
+        // Keep the status-based fallback when the server does not return JSON.
+      }
+      throw new ApiError(message, response.status);
     }
     const data = await response.json();
     return data;

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
@@ -1,0 +1,45 @@
+import { createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/check", () => ({
+  addCheck: vi.fn(),
+  archiveCheck: vi.fn(),
+  fetchUserDefinedChecks: vi.fn().mockResolvedValue([]),
+}));
+
+import { addCheck } from "@/api/check";
+import eligibilityCheckResource from "./eligibilityCheckResource";
+
+describe("eligibilityCheckResource", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("propagates create failures to the modal", async () => {
+    const failure = new Error("That check name is already in use.");
+    vi.mocked(addCheck).mockRejectedValue(failure);
+
+    await new Promise<void>((resolve, reject) => {
+      createRoot((dispose) => {
+        const resource = eligibilityCheckResource();
+        resource.actions
+          .addNewCheck({
+            name: "incomeCheck",
+            module: "income",
+            description: "Checks income",
+            parameterDefinitions: [],
+          })
+          .then(() => reject(new Error("Expected check creation to fail")))
+          .catch((error) => {
+            try {
+              expect(error).toBe(failure);
+              expect(resource.actionInProgress()).toBe(false);
+              resolve();
+            } catch (assertionError) {
+              reject(assertionError);
+            } finally {
+              dispose();
+            }
+          });
+      });
+    });
+  });
+});

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
@@ -39,8 +39,10 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
       await refetch();
     } catch (e) {
       console.error("Failed to add new check", e);
+      throw e;
+    } finally {
+      setActionInProgress(false);
     }
-    setActionInProgress(false);
   };
 
   const removeCheck = async (checkIdToRemove: string) => {

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/CheckModal.test.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/CheckModal.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { render } from "solid-js/web";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/check";
+import CheckModal from "./CheckModal";
+
+describe("CheckModal", () => {
+  let dispose: (() => void) | undefined;
+
+  afterEach(() => dispose?.());
+
+  it("displays a rejected name under the check name input", async () => {
+    const container = document.createElement("div");
+    const onClose = vi.fn();
+    const message =
+      'A check named "incomeCheck" in module "income" is archived. Restore it or choose a different name.';
+
+    dispose = renderModal(container, new ApiError(message, 409), onClose);
+    await submit(container);
+
+    expect(fieldError(container, "checkName")).toBe(message);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failed request out of the check name error", async () => {
+    const container = document.createElement("div");
+    const onClose = vi.fn();
+    const message = "Post failed with status: 503";
+
+    dispose = renderModal(container, new ApiError(message, 503), onClose);
+    await submit(container);
+
+    // The name was never the problem, so it must not be blamed for the failure.
+    expect(fieldError(container, "checkName")).toBe("");
+    expect(container.textContent).toContain(message);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("reports a network failure without blaming the check name", async () => {
+    const container = document.createElement("div");
+    const onClose = vi.fn();
+    const message = "Failed to fetch";
+
+    dispose = renderModal(container, new TypeError(message), onClose);
+    await submit(container);
+
+    expect(fieldError(container, "checkName")).toBe("");
+    expect(container.textContent).toContain(message);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+function renderModal(
+  container: HTMLElement,
+  failure: Error,
+  onClose: () => void,
+) {
+  return render(
+    () => (
+      <CheckModal
+        onAddCheck={() => Promise.reject(failure)}
+        onClose={onClose}
+      />
+    ),
+    container,
+  );
+}
+
+async function submit(container: HTMLElement) {
+  setInput(container, "checkName", "incomeCheck");
+  setInput(container, "checkModule", "income");
+  setInput(container, "checkDescription", "Checks income");
+  container
+    .querySelector("form")!
+    .dispatchEvent(
+      new SubmitEvent("submit", { bubbles: true, cancelable: true }),
+    );
+  await Promise.resolve();
+}
+
+function setInput(container: HTMLElement, name: string, value: string) {
+  const input = container.querySelector<HTMLInputElement>(
+    `input[name="${name}"]`,
+  )!;
+  input.value = value;
+  input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+}
+
+/* The error slot for a field is the element following that field's wrapper. */
+function fieldError(container: HTMLElement, name: string) {
+  const input = container.querySelector<HTMLInputElement>(
+    `input[name="${name}"]`,
+  )!;
+  return input.parentElement!.nextElementSibling!.textContent ?? "";
+}

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/CheckModal.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/CheckModal.tsx
@@ -3,6 +3,7 @@ import { createSignal, JSX } from "solid-js";
 import Form from "@/components/shared/Form";
 import { Button } from "@/components/shared/Button";
 import { checkNameError } from "@/utils/checkName";
+import { ApiError } from "@/api/check";
 
 interface Props {
   onAddCheck: (check: CreateCheckRequest) => Promise<void>;
@@ -14,6 +15,7 @@ const EditCheckModal = (props: Props) => {
     checkName: "",
     module: "",
     description: "",
+    form: "",
   });
 
   const handleAddCheck: JSX.EventHandler<HTMLFormElement, SubmitEvent> = async (
@@ -35,6 +37,7 @@ const EditCheckModal = (props: Props) => {
         checkName: nameError ?? "",
         module: !checkModule ? "Please enter a module." : "",
         description: !checkDescription ? "Please enter a description." : "",
+        form: "",
       });
     } else {
       const check: CreateCheckRequest = {
@@ -47,7 +50,17 @@ const EditCheckModal = (props: Props) => {
         await props.onAddCheck(check);
         props.onClose();
       } catch (err) {
-        console.log(err);
+        // Only a rejected name belongs under the name input. Every other failure
+        // is the request itself going wrong, and reads as a naming rule there.
+        const message =
+          err instanceof Error ? err.message : "Could not create check.";
+        const nameRejected = err instanceof ApiError && err.status === 409;
+        setError({
+          checkName: nameRejected ? message : "",
+          module: "",
+          description: "",
+          form: nameRejected ? "" : message,
+        });
       }
     }
   };
@@ -70,6 +83,8 @@ const EditCheckModal = (props: Props) => {
           <Form.TextInput />
         </Form.LabelAbove>
         <Form.FormError>{error().description}</Form.FormError>
+
+        <Form.FormError>{error().form}</Form.FormError>
         <Button type="submit">Add Check</Button>
       </Form>
     </div>


### PR DESCRIPTION
Closes #484

## Summary

- return 409 responses with actionable messages for active and archived duplicate checks
- preserve Firestore create as an atomic backstop for concurrent duplicate requests
- propagate API errors through the frontend and keep the create modal open
- distinguish duplicate-name errors from general request failures in the modal
- add backend and frontend regression coverage

## Verification

- `devbox run -q -- mvn -f builder-api/pom.xml -Dtest=EligibilityCheckResourceTest test` (9 passed)
- `devbox run -q -- npm --prefix builder-frontend test` (35 passed)
- `devbox run -q -- npm --prefix builder-frontend run build`