### PR TITLE
Fix archived check collision response

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -87,7 +87,7 @@ public class EligibilityCheckResource {
         );
         String checkId = eligibilityCheckRepository.getWorkingId(newCheck);
         Optional<EligibilityCheck> existingCheck = eligibilityCheckRepository
-                .getWorkingCustomCheck(userId, checkId, true);
+                .getWorkingCustomCheckMetadata(userId, checkId);
         if (existingCheck.isPresent()) {
             return duplicateCheckResponse(request, existingCheck.get().getIsArchived());
         }
@@ -99,11 +99,17 @@ public class EligibilityCheckResource {
         } catch (DocumentAlreadyExistsException e) {
             Log.info("Check " + checkId + " already exists after attempted creation");
             // The preflight lookup may have returned empty because its read failed, so inspect the
-            // document again before describing the colliding check's archive state.
-            Optional<EligibilityCheck> collidingCheck = eligibilityCheckRepository
-                    .getWorkingCustomCheck(userId, checkId, true);
-            if (collidingCheck.isPresent()) {
-                return duplicateCheckResponse(request, collidingCheck.get().getIsArchived());
+            // document again before describing the colliding check's archive state. This read sits
+            // outside the sibling catch blocks, so it has to handle its own failures.
+            try {
+                Optional<EligibilityCheck> collidingCheck = eligibilityCheckRepository
+                        .getWorkingCustomCheckMetadata(userId, checkId);
+                if (collidingCheck.isPresent()) {
+                    return duplicateCheckResponse(request, collidingCheck.get().getIsArchived());
+                }
+            } catch (Exception readFailure) {
+                Log.error("Could not read the check " + checkId + " that collided with the new check",
+                        readFailure);
             }
             return duplicateCheckResponse(request);
         } catch (Exception e){

--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -97,8 +97,15 @@ public class EligibilityCheckResource {
         try {
             checkId = eligibilityCheckRepository.saveNewWorkingCustomCheck(newCheck);
         } catch (DocumentAlreadyExistsException e) {
-            Log.info("Check " + checkId + " was created concurrently");
-            return duplicateCheckResponse(request, false);
+            Log.info("Check " + checkId + " already exists after attempted creation");
+            // The preflight lookup may have returned empty because its read failed, so inspect the
+            // document again before describing the colliding check's archive state.
+            Optional<EligibilityCheck> collidingCheck = eligibilityCheckRepository
+                    .getWorkingCustomCheck(userId, checkId, true);
+            if (collidingCheck.isPresent()) {
+                return duplicateCheckResponse(request, collidingCheck.get().getIsArchived());
+            }
+            return duplicateCheckResponse(request);
         } catch (Exception e){
             Log.error("Could not save new check for user " + userId, e);
             return  Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -138,6 +145,15 @@ public class EligibilityCheckResource {
                     + "\" is archived. Restore it or choose a different name."
                 : "You already have a check named \"" + request.name() + "\" in module \""
                     + request.module() + "\".";
+        return duplicateCheckResponse(message);
+    }
+
+    private Response duplicateCheckResponse(CreateCheckRequest request) {
+        return duplicateCheckResponse("A check named \"" + request.name() + "\" in module \""
+                + request.module() + "\" already exists.");
+    }
+
+    private Response duplicateCheckResponse(String message) {
         return Response.status(Response.Status.CONFLICT)
                 .type(MediaType.APPLICATION_JSON)
                 .entity(Map.of("error", message))

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -20,6 +20,9 @@ public interface EligibilityCheckRepository {
 
     Optional<EligibilityCheck> getWorkingCustomCheck(String userId, String checkId, boolean includeArchived);
 
+    /* The working check document, archived or not, without its DMN model. */
+    Optional<EligibilityCheck> getWorkingCustomCheckMetadata(String userId, String checkId);
+
     Optional<EligibilityCheck> getPublishedCustomCheck(String userId, String checkId);
 
     String getWorkingId(EligibilityCheck check);

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -95,6 +95,10 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
         return checkOpt;
     }
 
+    public Optional<EligibilityCheck> getWorkingCustomCheckMetadata(String userId, String checkId){
+        return getCustomCheck(userId, checkId, false, false);
+    }
+
     public Optional<EligibilityCheck> getPublishedCustomCheck(String userId, String checkId){
         Optional<EligibilityCheck> publishedCheckOpt = getCustomCheck(userId, checkId, true);
         if (publishedCheckOpt.isEmpty()) {
@@ -115,6 +119,11 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
     }
 
     private Optional<EligibilityCheck> getCustomCheck(String userId, String checkId, boolean isPublished){
+        return getCustomCheck(userId, checkId, isPublished, true);
+    }
+
+    private Optional<EligibilityCheck> getCustomCheck(String userId, String checkId, boolean isPublished,
+                                                      boolean includeDmnModel){
         String collectionName = isPublished ? CollectionNames.PUBLISHED_CUSTOM_CHECK_COLLECTION : CollectionNames.WORKING_CUSTOM_CHECK_COLLECTION;
 
         Optional<Map<String, Object>> checkMap = FirestoreUtils.getFirestoreDocById(collectionName, checkId);
@@ -126,9 +135,11 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
         ObjectMapper mapper = new ObjectMapper();
         EligibilityCheck check = mapper.convertValue(data, EligibilityCheck.class);
 
-        String dmnPath = storageService.getCheckDmnModelPath(checkId);
-        Optional<String> dmnModel = storageService.getStringFromStorage(dmnPath);
-        dmnModel.ifPresent(check::setDmnModel);
+        if (includeDmnModel) {
+            String dmnPath = storageService.getCheckDmnModelPath(checkId);
+            Optional<String> dmnModel = storageService.getStringFromStorage(dmnPath);
+            dmnModel.ifPresent(check::setDmnModel);
+        }
 
         return Optional.of(check);
     }

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -173,7 +173,28 @@ class EligibilityCheckResourceTest {
 
         assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
         assertEquals(
-                "You already have a check named \"incomeCheck\" in module \"income\".",
+                "A check named \"incomeCheck\" in module \"income\" already exists.",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void createCustomCheckReportsArchivedStateAfterAWriteCollision() throws Exception {
+        CreateCheckRequest request = createCheckRequest();
+        String checkId = "W-owner-1-income-incomeCheck";
+        EligibilityCheck archivedCheck = new EligibilityCheck(
+                request.name(), request.module(), request.description(), List.of(), USER_ID);
+        archivedCheck.setIsArchived(true);
+        when(repository.getWorkingCustomCheck(USER_ID, checkId, true))
+                .thenReturn(Optional.empty(), Optional.of(archivedCheck));
+        when(repository.saveNewWorkingCustomCheck(any()))
+                .thenThrow(new DocumentAlreadyExistsException(checkId, new RuntimeException()));
+
+        Response response = resource.createCustomCheck(identity, request);
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        assertEquals(
+                "A check named \"incomeCheck\" in module \"income\" is archived. Restore it or choose a different name.",
                 ((java.util.Map<?, ?>) response.getEntity()).get("error"));
         verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
     }

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -132,7 +132,7 @@ class EligibilityCheckResourceTest {
         String checkId = "W-owner-1-income-incomeCheck";
         EligibilityCheck existing = new EligibilityCheck(
                 request.name(), request.module(), request.description(), List.of(), USER_ID);
-        when(repository.getWorkingCustomCheck(USER_ID, checkId, true)).thenReturn(Optional.of(existing));
+        when(repository.getWorkingCustomCheckMetadata(USER_ID, checkId)).thenReturn(Optional.of(existing));
 
         Response response = resource.createCustomCheck(identity, request);
 
@@ -151,7 +151,7 @@ class EligibilityCheckResourceTest {
         EligibilityCheck existing = new EligibilityCheck(
                 request.name(), request.module(), request.description(), List.of(), USER_ID);
         existing.setIsArchived(true);
-        when(repository.getWorkingCustomCheck(USER_ID, checkId, true)).thenReturn(Optional.of(existing));
+        when(repository.getWorkingCustomCheckMetadata(USER_ID, checkId)).thenReturn(Optional.of(existing));
 
         Response response = resource.createCustomCheck(identity, request);
 
@@ -185,7 +185,7 @@ class EligibilityCheckResourceTest {
         EligibilityCheck archivedCheck = new EligibilityCheck(
                 request.name(), request.module(), request.description(), List.of(), USER_ID);
         archivedCheck.setIsArchived(true);
-        when(repository.getWorkingCustomCheck(USER_ID, checkId, true))
+        when(repository.getWorkingCustomCheckMetadata(USER_ID, checkId))
                 .thenReturn(Optional.empty(), Optional.of(archivedCheck));
         when(repository.saveNewWorkingCustomCheck(any()))
                 .thenThrow(new DocumentAlreadyExistsException(checkId, new RuntimeException()));
@@ -195,6 +195,25 @@ class EligibilityCheckResourceTest {
         assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
         assertEquals(
                 "A check named \"incomeCheck\" in module \"income\" is archived. Restore it or choose a different name.",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void createCustomCheckStillConflictsWhenTheCollidingCheckCannotBeRead() throws Exception {
+        CreateCheckRequest request = createCheckRequest();
+        String checkId = "W-owner-1-income-incomeCheck";
+        when(repository.getWorkingCustomCheckMetadata(USER_ID, checkId))
+                .thenReturn(Optional.empty())
+                .thenThrow(new IllegalArgumentException("unmappable document"));
+        when(repository.saveNewWorkingCustomCheck(any()))
+                .thenThrow(new DocumentAlreadyExistsException(checkId, new RuntimeException()));
+
+        Response response = resource.createCustomCheck(identity, request);
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        assertEquals(
+                "A check named \"incomeCheck\" in module \"income\" already exists.",
                 ((java.util.Map<?, ?>) response.getEntity()).get("error"));
         verify(storageService, never()).writeStringToStorage(anyString(), anyString(), anyString());
     }


### PR DESCRIPTION
## Summary

- re-read a colliding working check after an atomic create conflict
- report its actual archived state when available
- use a state-neutral conflict message when the follow-up read is inconclusive
- add regression coverage for archived and inconclusive write collisions

## Testing

- devbox run -q -- mvn -q -f builder-api/pom.xml test

Closes #488