### PR TITLE
Add restore flow for archived checks

### DIFF
--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -50,7 +50,9 @@ public class EligibilityCheckResource {
     // If the query parameter 'working' is set to true,
     // then the active (non-archived) working check objects owned by the user are returned
     // Adding 'includeArchived=true' to a working request returns the archived ones alongside them,
-    // so a caller that renders both lists can do it with a single read
+    // so a caller that renders both lists can do it with a single read.
+    // Published checks are never archived, so 'includeArchived=true' without 'working=true'
+    // is rejected rather than silently answered with an unfiltered published list
     @GET
     public Response getCustomChecks(
         @Context SecurityIdentity identity,
@@ -60,6 +62,12 @@ public class EligibilityCheckResource {
         String userId = AuthUtils.getUserId(identity);
         if (userId == null) {
             return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        if (Boolean.TRUE.equals(includeArchived) && !Boolean.TRUE.equals(working)) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "includeArchived requires working=true"))
+                    .build();
         }
 
         List<EligibilityCheck> checks;

--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -48,12 +48,14 @@ public class EligibilityCheckResource {
 
     // By default, returns the most recent versions of all published checks owned by the calling user
     // If the query parameter 'working' is set to true,
-    // then all the working check objects owned by the user are returned
+    // then the active (non-archived) working check objects owned by the user are returned
+    // Adding 'includeArchived=true' to a working request returns the archived ones alongside them,
+    // so a caller that renders both lists can do it with a single read
     @GET
     public Response getCustomChecks(
         @Context SecurityIdentity identity,
         @QueryParam("working") Boolean working,
-        @QueryParam("archived") Boolean archived
+        @QueryParam("includeArchived") Boolean includeArchived
     ) {
         String userId = AuthUtils.getUserId(identity);
         if (userId == null) {
@@ -63,9 +65,9 @@ public class EligibilityCheckResource {
         List<EligibilityCheck> checks;
 
         if (Boolean.TRUE.equals(working)){
-            if (Boolean.TRUE.equals(archived)) {
-                Log.info("Fetching archived custom checks. User:  " + userId);
-                checks = eligibilityCheckRepository.getArchivedCustomChecks(userId);
+            if (Boolean.TRUE.equals(includeArchived)) {
+                Log.info("Fetching active and archived custom checks. User:  " + userId);
+                checks = eligibilityCheckRepository.getAllWorkingCustomChecks(userId);
             } else {
                 Log.info("Fetching active working custom checks. User:  " + userId);
                 checks = eligibilityCheckRepository.getWorkingCustomChecks(userId);

--- a/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
+++ b/builder-api/src/main/java/org/acme/controller/EligibilityCheckResource.java
@@ -52,7 +52,8 @@ public class EligibilityCheckResource {
     @GET
     public Response getCustomChecks(
         @Context SecurityIdentity identity,
-        @QueryParam("working") Boolean working
+        @QueryParam("working") Boolean working,
+        @QueryParam("archived") Boolean archived
     ) {
         String userId = AuthUtils.getUserId(identity);
         if (userId == null) {
@@ -61,9 +62,14 @@ public class EligibilityCheckResource {
 
         List<EligibilityCheck> checks;
 
-        if (working != null && working){
-            Log.info("Fetching all working custom checks. User:  " + userId);
-            checks = eligibilityCheckRepository.getWorkingCustomChecks(userId);
+        if (Boolean.TRUE.equals(working)){
+            if (Boolean.TRUE.equals(archived)) {
+                Log.info("Fetching archived custom checks. User:  " + userId);
+                checks = eligibilityCheckRepository.getArchivedCustomChecks(userId);
+            } else {
+                Log.info("Fetching active working custom checks. User:  " + userId);
+                checks = eligibilityCheckRepository.getWorkingCustomChecks(userId);
+            }
         } else {
             Log.info("Fetching all published custom checks. User:  " + userId);
             checks = eligibilityCheckRepository.getLatestVersionPublishedCustomChecks(userId);
@@ -431,6 +437,43 @@ public class EligibilityCheckResource {
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(Map.of("error", "Could not archive check"))
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/{checkId}/restore")
+    public Response restoreCustomCheck(@Context SecurityIdentity identity, @PathParam("checkId") String checkId) {
+        String userId = AuthUtils.getUserId(identity);
+        if (userId == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        Optional<EligibilityCheck> checkOpt = eligibilityCheckRepository
+                .getWorkingCustomCheck(userId, checkId, true);
+        if (checkOpt.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        EligibilityCheck check = checkOpt.get();
+        if (!check.getOwnerId().equals(userId)) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        if (!check.getIsArchived()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "Check is not archived"))
+                    .build();
+        }
+
+        check.setIsArchived(false);
+        try {
+            eligibilityCheckRepository.updateWorkingCustomCheck(check);
+            return Response.ok(check, MediaType.APPLICATION_JSON).build();
+        } catch (Exception e) {
+            Log.error("Could not restore check " + checkId, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(Map.of("error", "Could not restore check"))
                     .build();
         }
     }

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -10,7 +10,7 @@ public interface EligibilityCheckRepository {
 
     List<EligibilityCheck> getWorkingCustomChecks(String userId);
 
-    List<EligibilityCheck> getArchivedCustomChecks(String userId);
+    List<EligibilityCheck> getAllWorkingCustomChecks(String userId);
 
     List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck) throws Exception;
 

--- a/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
+++ b/builder-api/src/main/java/org/acme/persistence/EligibilityCheckRepository.java
@@ -10,6 +10,8 @@ public interface EligibilityCheckRepository {
 
     List<EligibilityCheck> getWorkingCustomChecks(String userId);
 
+    List<EligibilityCheck> getArchivedCustomChecks(String userId);
+
     List<EligibilityCheck> getPublishedCheckVersions(EligibilityCheck workingCustomCheck) throws Exception;
 
     List<EligibilityCheck> getLatestVersionPublishedCustomChecks(String userId);

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -28,19 +28,16 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
     private StorageService storageService;
 
     public List<EligibilityCheck> getWorkingCustomChecks(String userId){
-        return getWorkingCustomChecksByArchivedStatus(userId, false);
+        return getAllWorkingCustomChecks(userId).stream()
+                .filter(check -> !check.getIsArchived())
+                .toList();
     }
 
-    public List<EligibilityCheck> getArchivedCustomChecks(String userId){
-        return getWorkingCustomChecksByArchivedStatus(userId, true);
-    }
-
-    private List<EligibilityCheck> getWorkingCustomChecksByArchivedStatus(String userId, boolean archived){
+    public List<EligibilityCheck> getAllWorkingCustomChecks(String userId){
         List<Map<String, Object>> checkMaps = FirestoreUtils.getFirestoreDocsByField(CollectionNames.WORKING_CUSTOM_CHECK_COLLECTION, FieldNames.OWNER_ID, userId);
         ObjectMapper mapper = new ObjectMapper();
         return checkMaps.stream()
                 .map(checkMap -> mapper.convertValue(checkMap, EligibilityCheck.class))
-                .filter(check -> check.getIsArchived() == archived)
                 .toList();
     }
 

--- a/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
+++ b/builder-api/src/main/java/org/acme/persistence/impl/EligibilityCheckRepositoryImpl.java
@@ -28,11 +28,19 @@ public class EligibilityCheckRepositoryImpl implements EligibilityCheckRepositor
     private StorageService storageService;
 
     public List<EligibilityCheck> getWorkingCustomChecks(String userId){
+        return getWorkingCustomChecksByArchivedStatus(userId, false);
+    }
+
+    public List<EligibilityCheck> getArchivedCustomChecks(String userId){
+        return getWorkingCustomChecksByArchivedStatus(userId, true);
+    }
+
+    private List<EligibilityCheck> getWorkingCustomChecksByArchivedStatus(String userId, boolean archived){
         List<Map<String, Object>> checkMaps = FirestoreUtils.getFirestoreDocsByField(CollectionNames.WORKING_CUSTOM_CHECK_COLLECTION, FieldNames.OWNER_ID, userId);
         ObjectMapper mapper = new ObjectMapper();
         return checkMaps.stream()
                 .map(checkMap -> mapper.convertValue(checkMap, EligibilityCheck.class))
-                .filter(check -> !check.getIsArchived())
+                .filter(check -> check.getIsArchived() == archived)
                 .toList();
     }
 

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -228,18 +228,31 @@ class EligibilityCheckResourceTest {
     }
 
     @Test
-    void getCustomChecksCanListArchivedChecks() {
+    void getCustomChecksCanIncludeArchivedChecksInOneRead() {
         EligibilityCheck archivedCheck = new EligibilityCheck(
                 "old-check", "income", "an old check", List.of(), USER_ID);
         archivedCheck.setIsArchived(true);
-        when(repository.getArchivedCustomChecks(USER_ID)).thenReturn(List.of(archivedCheck));
+        when(repository.getAllWorkingCustomChecks(USER_ID))
+                .thenReturn(List.of(workingCheck, archivedCheck));
 
         Response response = resource.getCustomChecks(identity, true, true);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        assertEquals(List.of(archivedCheck), response.getEntity());
-        verify(repository).getArchivedCustomChecks(USER_ID);
+        assertEquals(List.of(workingCheck, archivedCheck), response.getEntity());
+        verify(repository).getAllWorkingCustomChecks(USER_ID);
         verify(repository, never()).getWorkingCustomChecks(USER_ID);
+    }
+
+    @Test
+    void getCustomChecksOmitsArchivedChecksByDefault() {
+        when(repository.getWorkingCustomChecks(USER_ID)).thenReturn(List.of(workingCheck));
+
+        Response response = resource.getCustomChecks(identity, true, null);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(List.of(workingCheck), response.getEntity());
+        verify(repository).getWorkingCustomChecks(USER_ID);
+        verify(repository, never()).getAllWorkingCustomChecks(USER_ID);
     }
 
     @Test

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -256,6 +256,16 @@ class EligibilityCheckResourceTest {
     }
 
     @Test
+    void getCustomChecksRejectsIncludeArchivedWithoutWorking() {
+        Response response = resource.getCustomChecks(identity, null, true);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("includeArchived requires working=true",
+                ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(repository, never()).getLatestVersionPublishedCustomChecks(USER_ID);
+    }
+
+    @Test
     void restoreCustomCheckMakesAnArchivedCheckActive() throws Exception {
         workingCheck.setIsArchived(true);
         when(repository.getWorkingCustomCheck(USER_ID, CHECK_ID, true))

--- a/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
+++ b/builder-api/src/test/java/org/acme/controller/EligibilityCheckResourceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -224,6 +225,56 @@ class EligibilityCheckResourceTest {
                 "income",
                 "Checks the applicant's income",
                 List.of());
+    }
+
+    @Test
+    void getCustomChecksCanListArchivedChecks() {
+        EligibilityCheck archivedCheck = new EligibilityCheck(
+                "old-check", "income", "an old check", List.of(), USER_ID);
+        archivedCheck.setIsArchived(true);
+        when(repository.getArchivedCustomChecks(USER_ID)).thenReturn(List.of(archivedCheck));
+
+        Response response = resource.getCustomChecks(identity, true, true);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(List.of(archivedCheck), response.getEntity());
+        verify(repository).getArchivedCustomChecks(USER_ID);
+        verify(repository, never()).getWorkingCustomChecks(USER_ID);
+    }
+
+    @Test
+    void restoreCustomCheckMakesAnArchivedCheckActive() throws Exception {
+        workingCheck.setIsArchived(true);
+        when(repository.getWorkingCustomCheck(USER_ID, CHECK_ID, true))
+                .thenReturn(Optional.of(workingCheck));
+
+        Response response = resource.restoreCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertFalse(workingCheck.getIsArchived());
+        verify(repository).updateWorkingCustomCheck(workingCheck);
+    }
+
+    @Test
+    void restoreCustomCheckRejectsAnActiveCheck() throws Exception {
+        when(repository.getWorkingCustomCheck(USER_ID, CHECK_ID, true))
+                .thenReturn(Optional.of(workingCheck));
+
+        Response response = resource.restoreCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Check is not archived", ((java.util.Map<?, ?>) response.getEntity()).get("error"));
+        verify(repository, never()).updateWorkingCustomCheck(any());
+    }
+
+    @Test
+    void restoreCustomCheckReturnsNotFoundForAnUnknownCheck() {
+        when(repository.getWorkingCustomCheck(USER_ID, CHECK_ID, true))
+                .thenReturn(Optional.empty());
+
+        Response response = resource.restoreCustomCheck(identity, CHECK_ID);
+
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
     @Test

--- a/builder-frontend/src/api/check.ts
+++ b/builder-frontend/src/api/check.ts
@@ -153,9 +153,12 @@ export const validateCheckDmn = async (
 
 export const fetchUserDefinedChecks = async (
   working: boolean,
+  archived = false,
 ): Promise<EligibilityCheck[]> => {
   const workingQueryParam = working ? "true" : "false";
-  let url: string = apiUrl + `/custom-checks?working=${workingQueryParam}`;
+  const archivedQueryParam = archived ? "&archived=true" : "";
+  const url =
+    apiUrl + `/custom-checks?working=${workingQueryParam}${archivedQueryParam}`;
 
   try {
     const response = await authGet(url);
@@ -240,6 +243,20 @@ export const archiveCheck = async (checkId: string): Promise<void> => {
     }
   } catch (error) {
     console.error("Error archiving check:", error);
+    throw error;
+  }
+};
+
+export const restoreCheck = async (checkId: string): Promise<void> => {
+  const url = apiUrl + `/custom-checks/${checkId}/restore`;
+  try {
+    const response = await authPost(url);
+
+    if (!response.ok) {
+      throw new Error(`Restore failed with status: ${response.status}`);
+    }
+  } catch (error) {
+    console.error("Error restoring check:", error);
     throw error;
   }
 };

--- a/builder-frontend/src/api/check.ts
+++ b/builder-frontend/src/api/check.ts
@@ -151,14 +151,20 @@ export const validateCheckDmn = async (
   }
 };
 
-export const fetchUserDefinedChecks = async (
-  working: boolean,
-  archived = false,
-): Promise<EligibilityCheck[]> => {
+export const fetchUserDefinedChecks = async ({
+  working,
+  includeArchived = false,
+}: {
+  working: boolean;
+  includeArchived?: boolean;
+}): Promise<EligibilityCheck[]> => {
   const workingQueryParam = working ? "true" : "false";
-  const archivedQueryParam = archived ? "&archived=true" : "";
+  const includeArchivedQueryParam = includeArchived
+    ? "&includeArchived=true"
+    : "";
   const url =
-    apiUrl + `/custom-checks?working=${workingQueryParam}${archivedQueryParam}`;
+    apiUrl +
+    `/custom-checks?working=${workingQueryParam}${includeArchivedQueryParam}`;
 
   try {
     const response = await authGet(url);

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Setter, Show } from "solid-js";
+import { Accessor, createSignal, For, Setter, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 
 import Loading from "@/components/Loading";
@@ -110,6 +110,7 @@ const EligibilityChecksList = () => {
                       setCheckIdToRemove={setCheckIdToRemove}
                       archived
                       onRestore={() => actions.restoreCheck(check.id)}
+                      actionInProgress={actionInProgress}
                     />
                   )}
                 </For>
@@ -141,12 +142,14 @@ const CheckCard = ({
   setCheckIdToRemove,
   archived = false,
   onRestore,
+  actionInProgress,
 }: {
   eligibilityCheck: EligibilityCheck;
   navigateToCheck: (check: EligibilityCheck) => void;
   setCheckIdToRemove: Setter<string>;
   archived?: boolean;
   onRestore?: () => Promise<void>;
+  actionInProgress?: Accessor<boolean>;
 }) => {
   return (
     <div class="w-full flex">
@@ -192,7 +195,12 @@ const CheckCard = ({
               </>
             }
           >
-            <Button onClick={() => void onRestore?.()}>Restore</Button>
+            <Button
+              disabled={actionInProgress?.()}
+              onClick={() => void onRestore?.()}
+            >
+              Restore
+            </Button>
           </Show>
         </div>
       </div>

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/EligibilityChecksList.tsx
@@ -13,11 +13,18 @@ import { ArchiveCheck } from "@/components/homeScreen/eligibilityCheckList/modal
 import { Button } from "@/components/shared/Button";
 
 const EligibilityChecksList = () => {
-  const { checks, actions, actionInProgress, initialLoadStatus } =
-    eligibilityCheckResource();
+  const {
+    checks,
+    archivedChecks,
+    actions,
+    actionInProgress,
+    initialLoadStatus,
+  } = eligibilityCheckResource();
   const navigate = useNavigate();
 
   const [addingNewCheck, setAddingNewCheck] = createSignal<boolean>(false);
+  const [showArchivedChecks, setShowArchivedChecks] =
+    createSignal<boolean>(false);
 
   const [checkIdToRemove, setCheckIdToRemove] = createSignal<null | string>(
     null,
@@ -77,6 +84,40 @@ const EligibilityChecksList = () => {
           )}
         </For>
       </div>
+      <Show when={archivedChecks().length > 0}>
+        <div class="mt-8 border-t border-gray-300 pt-4">
+          <Button
+            variant="outline-secondary"
+            aria-expanded={showArchivedChecks()}
+            aria-controls="archived-checks"
+            onClick={() => setShowArchivedChecks((shown) => !shown)}
+          >
+            {showArchivedChecks() ? "Hide" : "Show"} archived checks (
+            {archivedChecks().length})
+          </Button>
+          <Show when={showArchivedChecks()}>
+            <section id="archived-checks" class="mt-4">
+              <h2 class="text-xl font-bold mb-1">Archived checks</h2>
+              <p class="mb-4 text-gray-700">
+                Restore a check to edit it or use its name again.
+              </p>
+              <div class="grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+                <For each={archivedChecks()}>
+                  {(check) => (
+                    <CheckCard
+                      eligibilityCheck={check}
+                      navigateToCheck={navigateToCheck}
+                      setCheckIdToRemove={setCheckIdToRemove}
+                      archived
+                      onRestore={() => actions.restoreCheck(check.id)}
+                    />
+                  )}
+                </For>
+              </div>
+            </section>
+          </Show>
+        </div>
+      </Show>
       <Modal
         show={checkIdToRemove() !== null}
         onClose={() => setCheckIdToRemove(null)}
@@ -98,10 +139,14 @@ const CheckCard = ({
   eligibilityCheck,
   navigateToCheck,
   setCheckIdToRemove,
+  archived = false,
+  onRestore,
 }: {
   eligibilityCheck: EligibilityCheck;
   navigateToCheck: (check: EligibilityCheck) => void;
   setCheckIdToRemove: Setter<string>;
+  archived?: boolean;
+  onRestore?: () => Promise<void>;
 }) => {
   return (
     <div class="w-full flex">
@@ -124,22 +169,31 @@ const CheckCard = ({
           id={"benefit-card-actions-" + eligibilityCheck.id}
           class="p-4 flex justify-end space-x-2"
         >
-          <Button
-            variant="outline-secondary"
-            onClick={() => {
-              navigateToCheck(eligibilityCheck);
-            }}
+          <Show
+            when={archived}
+            fallback={
+              <>
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => {
+                    navigateToCheck(eligibilityCheck);
+                  }}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="outline-danger"
+                  onClick={() => {
+                    setCheckIdToRemove(eligibilityCheck.id);
+                  }}
+                >
+                  Archive
+                </Button>
+              </>
+            }
           >
-            Edit
-          </Button>
-          <Button
-            variant="outline-danger"
-            onClick={() => {
-              setCheckIdToRemove(eligibilityCheck.id);
-            }}
-          >
-            Archive
-          </Button>
+            <Button onClick={() => void onRestore?.()}>Restore</Button>
+          </Show>
         </div>
       </div>
     </div>

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
@@ -4,10 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/api/check", () => ({
   addCheck: vi.fn(),
   archiveCheck: vi.fn(),
+  restoreCheck: vi.fn(),
   fetchUserDefinedChecks: vi.fn().mockResolvedValue([]),
 }));
 
-import { addCheck } from "@/api/check";
+vi.mock("solid-toast", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { addCheck, fetchUserDefinedChecks, restoreCheck } from "@/api/check";
 import eligibilityCheckResource from "./eligibilityCheckResource";
 
 describe("eligibilityCheckResource", () => {
@@ -39,6 +44,30 @@ describe("eligibilityCheckResource", () => {
               dispose();
             }
           });
+      });
+    });
+  });
+
+  it("restores a check and refreshes both active and archived lists", async () => {
+    await new Promise<void>((resolve, reject) => {
+      createRoot((dispose) => {
+        const resource = eligibilityCheckResource();
+        resource.actions
+          .restoreCheck("archived-check-id")
+          .then(() => {
+            try {
+              expect(restoreCheck).toHaveBeenCalledWith("archived-check-id");
+              expect(fetchUserDefinedChecks).toHaveBeenCalledWith(true);
+              expect(fetchUserDefinedChecks).toHaveBeenCalledWith(true, true);
+              expect(resource.actionInProgress()).toBe(false);
+              resolve();
+            } catch (assertionError) {
+              reject(assertionError);
+            } finally {
+              dispose();
+            }
+          })
+          .catch(reject);
       });
     });
   });

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
@@ -14,6 +14,7 @@ vi.mock("solid-toast", () => ({
 
 import { addCheck, fetchUserDefinedChecks, restoreCheck } from "@/api/check";
 import eligibilityCheckResource from "./eligibilityCheckResource";
+import type { EligibilityCheck } from "@/types";
 
 describe("eligibilityCheckResource", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -48,6 +49,33 @@ describe("eligibilityCheckResource", () => {
     });
   });
 
+  it("splits one response into the active and archived lists", async () => {
+    const active = { id: "active-id", isArchived: false };
+    const archived = { id: "archived-id", isArchived: true };
+    vi.mocked(fetchUserDefinedChecks).mockResolvedValue([
+      active,
+      archived,
+    ] as unknown as EligibilityCheck[]);
+
+    await new Promise<void>((resolve, reject) => {
+      createRoot((dispose) => {
+        const resource = eligibilityCheckResource();
+        queueMicrotask(() => {
+          try {
+            expect(fetchUserDefinedChecks).toHaveBeenCalledTimes(1);
+            expect(resource.checks()).toEqual([active]);
+            expect(resource.archivedChecks()).toEqual([archived]);
+            resolve();
+          } catch (assertionError) {
+            reject(assertionError);
+          } finally {
+            dispose();
+          }
+        });
+      });
+    });
+  });
+
   it("survives a failed fetch instead of throwing out of the effect", async () => {
     vi.mocked(fetchUserDefinedChecks).mockRejectedValue(
       new Error("Fetch failed with status: 500"),
@@ -72,7 +100,7 @@ describe("eligibilityCheckResource", () => {
     });
   });
 
-  it("restores a check and refreshes both active and archived lists", async () => {
+  it("restores a check and refreshes the check list", async () => {
     await new Promise<void>((resolve, reject) => {
       createRoot((dispose) => {
         const resource = eligibilityCheckResource();
@@ -81,8 +109,10 @@ describe("eligibilityCheckResource", () => {
           .then(() => {
             try {
               expect(restoreCheck).toHaveBeenCalledWith("archived-check-id");
-              expect(fetchUserDefinedChecks).toHaveBeenCalledWith(true);
-              expect(fetchUserDefinedChecks).toHaveBeenCalledWith(true, true);
+              expect(fetchUserDefinedChecks).toHaveBeenCalledWith({
+                working: true,
+                includeArchived: true,
+              });
               expect(resource.actionInProgress()).toBe(false);
               resolve();
             } catch (assertionError) {

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.test.ts
@@ -48,6 +48,30 @@ describe("eligibilityCheckResource", () => {
     });
   });
 
+  it("survives a failed fetch instead of throwing out of the effect", async () => {
+    vi.mocked(fetchUserDefinedChecks).mockRejectedValue(
+      new Error("Fetch failed with status: 500"),
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      createRoot((dispose) => {
+        const resource = eligibilityCheckResource();
+        queueMicrotask(() => {
+          try {
+            expect(resource.checks()).toEqual([]);
+            expect(resource.archivedChecks()).toEqual([]);
+            expect(resource.initialLoadStatus.error()).toBeInstanceOf(Error);
+            resolve();
+          } catch (assertionError) {
+            reject(assertionError);
+          } finally {
+            dispose();
+          }
+        });
+      });
+    });
+  });
+
   it("restores a check and refreshes both active and archived lists", async () => {
     await new Promise<void>((resolve, reject) => {
       createRoot((dispose) => {

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
@@ -1,14 +1,22 @@
 import { createResource, createEffect, Accessor, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
+import toast from "solid-toast";
 
 import type { EligibilityCheck, CreateCheckRequest } from "@/types";
-import { addCheck, archiveCheck, fetchUserDefinedChecks } from "@/api/check";
+import {
+  addCheck,
+  archiveCheck,
+  fetchUserDefinedChecks,
+  restoreCheck,
+} from "@/api/check";
 
 export interface EligibilityCheckResource {
   checks: () => EligibilityCheck[];
+  archivedChecks: () => EligibilityCheck[];
   actions: {
     addNewCheck: (check: CreateCheckRequest) => Promise<void>;
     removeCheck: (checkIdToRemove: string) => Promise<void>;
+    restoreCheck: (checkIdToRestore: string) => Promise<void>;
   };
   actionInProgress: Accessor<boolean>;
   initialLoadStatus: {
@@ -18,11 +26,18 @@ export interface EligibilityCheckResource {
 }
 
 const eligibilityCheckResource = (): EligibilityCheckResource => {
-  const [checksResource, { refetch }] = createResource(fetchUserDefinedChecks);
+  const [checksResource, { refetch: refetchChecks }] = createResource(() =>
+    fetchUserDefinedChecks(true),
+  );
+  const [archivedChecksResource, { refetch: refetchArchivedChecks }] =
+    createResource(() => fetchUserDefinedChecks(true, true));
   const [actionInProgress, setActionInProgress] = createSignal<boolean>(false);
 
   // Local fine-grained store
   const [checks, setChecks] = createStore<EligibilityCheck[]>([]);
+  const [archivedChecks, setArchivedChecks] = createStore<EligibilityCheck[]>(
+    [],
+  );
 
   // When resource resolves, sync it into the store
   createEffect(() => {
@@ -31,12 +46,18 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     }
   });
 
+  createEffect(() => {
+    if (archivedChecksResource()) {
+      setArchivedChecks(archivedChecksResource()!);
+    }
+  });
+
   // Actions
   const addNewCheck = async (check: CreateCheckRequest) => {
     setActionInProgress(true);
     try {
       await addCheck(check);
-      await refetch();
+      await refetchChecks();
     } catch (e) {
       console.error("Failed to add new check", e);
       throw e;
@@ -49,20 +70,42 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     setActionInProgress(true);
     try {
       await archiveCheck(checkIdToRemove);
-      await refetch();
+      await Promise.all([refetchChecks(), refetchArchivedChecks()]);
+      toast.success("Check archived.");
     } catch (e) {
       console.error("Failed to archive check", e);
+      toast.error("Could not archive check. Please try again.");
+    } finally {
+      setActionInProgress(false);
     }
-    setActionInProgress(false);
+  };
+
+  const restoreArchivedCheck = async (checkIdToRestore: string) => {
+    setActionInProgress(true);
+    try {
+      await restoreCheck(checkIdToRestore);
+      await Promise.all([refetchChecks(), refetchArchivedChecks()]);
+      toast.success("Check restored.");
+    } catch (e) {
+      console.error("Failed to restore check", e);
+      toast.error("Could not restore check. Please try again.");
+    } finally {
+      setActionInProgress(false);
+    }
   };
 
   return {
     checks: () => checks,
-    actions: { addNewCheck, removeCheck },
+    archivedChecks: () => archivedChecks,
+    actions: {
+      addNewCheck,
+      removeCheck,
+      restoreCheck: restoreArchivedCheck,
+    },
     actionInProgress,
     initialLoadStatus: {
-      loading: () => checksResource.loading,
-      error: () => checksResource.error,
+      loading: () => checksResource.loading || archivedChecksResource.loading,
+      error: () => checksResource.error ?? archivedChecksResource.error,
     },
   };
 };

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
@@ -26,11 +26,11 @@ export interface EligibilityCheckResource {
 }
 
 const eligibilityCheckResource = (): EligibilityCheckResource => {
+  // Both lists come from one request: the two are the same Firestore
+  // collection, so asking for them separately doubles the reads.
   const [checksResource, { refetch: refetchChecks }] = createResource(() =>
-    fetchUserDefinedChecks(true),
+    fetchUserDefinedChecks({ working: true, includeArchived: true }),
   );
-  const [archivedChecksResource, { refetch: refetchArchivedChecks }] =
-    createResource(() => fetchUserDefinedChecks(true, true));
   const [actionInProgress, setActionInProgress] = createSignal<boolean>(false);
 
   // Local fine-grained store
@@ -39,21 +39,15 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     [],
   );
 
-  // When resource resolves, sync it into the store. Reading an errored
-  // resource rethrows, so check for failure before touching the accessor.
+  // When the resource resolves, split it into the two stores. Reading an
+  // errored resource rethrows, so check for failure before touching the
+  // accessor.
   createEffect(() => {
     if (checksResource.error) return;
     const loadedChecks = checksResource();
     if (loadedChecks) {
-      setChecks(loadedChecks);
-    }
-  });
-
-  createEffect(() => {
-    if (archivedChecksResource.error) return;
-    const loadedArchivedChecks = archivedChecksResource();
-    if (loadedArchivedChecks) {
-      setArchivedChecks(loadedArchivedChecks);
+      setChecks(loadedChecks.filter((check) => !check.isArchived));
+      setArchivedChecks(loadedChecks.filter((check) => check.isArchived));
     }
   });
 
@@ -75,7 +69,7 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     setActionInProgress(true);
     try {
       await archiveCheck(checkIdToRemove);
-      await Promise.all([refetchChecks(), refetchArchivedChecks()]);
+      await refetchChecks();
       toast.success("Check archived.");
     } catch (e) {
       console.error("Failed to archive check", e);
@@ -89,7 +83,7 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     setActionInProgress(true);
     try {
       await restoreCheck(checkIdToRestore);
-      await Promise.all([refetchChecks(), refetchArchivedChecks()]);
+      await refetchChecks();
       toast.success("Check restored.");
     } catch (e) {
       console.error("Failed to restore check", e);
@@ -109,8 +103,8 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     },
     actionInProgress,
     initialLoadStatus: {
-      loading: () => checksResource.loading || archivedChecksResource.loading,
-      error: () => checksResource.error ?? archivedChecksResource.error,
+      loading: () => checksResource.loading,
+      error: () => checksResource.error,
     },
   };
 };

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/eligibilityCheckResource.ts
@@ -39,16 +39,21 @@ const eligibilityCheckResource = (): EligibilityCheckResource => {
     [],
   );
 
-  // When resource resolves, sync it into the store
+  // When resource resolves, sync it into the store. Reading an errored
+  // resource rethrows, so check for failure before touching the accessor.
   createEffect(() => {
-    if (checksResource()) {
-      setChecks(checksResource()!);
+    if (checksResource.error) return;
+    const loadedChecks = checksResource();
+    if (loadedChecks) {
+      setChecks(loadedChecks);
     }
   });
 
   createEffect(() => {
-    if (archivedChecksResource()) {
-      setArchivedChecks(archivedChecksResource()!);
+    if (archivedChecksResource.error) return;
+    const loadedArchivedChecks = archivedChecksResource();
+    if (loadedArchivedChecks) {
+      setArchivedChecks(loadedArchivedChecks);
     }
   });
 

--- a/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/ArchiveCheck.tsx
+++ b/builder-frontend/src/components/homeScreen/eligibilityCheckList/modals/ArchiveCheck.tsx
@@ -10,8 +10,8 @@ export const ArchiveCheck = (props: Props) => {
     <div>
       <div class="text-2xl font-bold mb-3">Archive Check</div>
       <div class="mb-4">
-        Are you sure you want to archive this Eligibility Check? This action
-        cannot be undone.
+        Are you sure you want to archive this Eligibility Check? You can restore
+        it later from the archived checks section.
       </div>
       <div class="flex justify-end space-x-2">
         <Button variant="outline-secondary" onClick={props.onCancel}>

--- a/builder-frontend/src/components/project/manageBenefits/configureBenefit/ConfigureBenefit.tsx
+++ b/builder-frontend/src/components/project/manageBenefits/configureBenefit/ConfigureBenefit.tsx
@@ -27,7 +27,7 @@ const ConfigureBenefit = ({
     createSignal<EligibilityCheckListMode>("public");
   const [publicChecks] = createResource<EligibilityCheck[]>(fetchPublicChecks);
   const [userDefinedChecks] = createResource<EligibilityCheck[]>(() =>
-    fetchUserDefinedChecks(false),
+    fetchUserDefinedChecks({ working: false }),
   );
 
   const onRemoveEligibilityCheck = (checkId: string) => {

--- a/builder-frontend/src/types.ts
+++ b/builder-frontend/src/types.ts
@@ -43,6 +43,7 @@ export interface EligibilityCheck {
   description: string;
   inputDefinition: JSONSchema7;
   parameterDefinitions: ParameterDefinition[];
+  isArchived?: boolean;
   // API endpoint for evaluating check (Library checks only)
   evaluationUrl?: string;
 }


### PR DESCRIPTION
## Summary

Archived custom checks can now be discovered and restored, so archived names are no longer permanently unusable.

## Changes

- Add archived-check listing and restore API support with ownership and state validation.
- Show archived checks in a collapsed frontend section with one-click restore.
- Refresh active and archived lists after archive/restore actions and disable conflicting actions while requests are in flight.
- Reject archived-list query parameters on published-check requests.
- Add backend and frontend coverage for archive/restore behavior and resource loading failures.

## Validation

- Builder API EligibilityCheckResourceTest: 18 tests passing.
- Focused frontend Vitest suite: 5 tests passing.
- Frontend production build passing.
- Prettier and git diff checks passing.